### PR TITLE
perf(dashboard-header): Extend Dashboard Header Page Title

### DIFF
--- a/apps/web/src/app/(dashboard)/team/[teamId]/active/page.tsx
+++ b/apps/web/src/app/(dashboard)/team/[teamId]/active/page.tsx
@@ -1,0 +1,11 @@
+/**
+ * The page for the active issues of a team.
+ * @returns The active issues page.
+ */
+export default function ActiveIssuesPage() {
+  return (
+    <div>
+      <h1>Active Issues</h1>
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import React from 'react'
+
 import type { SidebarStore } from '@/lib/store/sidebar-store'
 
 import { cn } from '@buildit/ui/cn'
@@ -18,7 +20,7 @@ export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode
-}): JSX.Element {
+}): React.JSX.Element {
   const store = useSidebarStore() as SidebarStore
 
   const hidden = store.hidden

--- a/apps/web/src/configs/layout-navigations.ts
+++ b/apps/web/src/configs/layout-navigations.ts
@@ -1,4 +1,10 @@
-export const getNavigations = () => {
+export interface Navigation {
+  name: string
+  icon: string
+  href: string
+}
+
+export const getNavigations = (): Navigation[] => {
   return [
     {
       name: 'My issues',
@@ -14,6 +20,30 @@ export const getNavigations = () => {
       name: 'Teams',
       icon: 'team',
       href: `/teams`,
+    },
+  ]
+}
+
+export const getTeamNavigations = ({
+  teamId,
+}: {
+  teamId: string
+}): Navigation[] => {
+  return [
+    {
+      name: 'Active issues',
+      icon: 'issues',
+      href: `/team/${teamId}/active`,
+    },
+    {
+      name: 'Backlog issues',
+      icon: 'backlog',
+      href: `/team/${teamId}/backlog`,
+    },
+    {
+      name: 'Projects',
+      icon: 'projects',
+      href: `/team/${teamId}/projects`,
     },
   ]
 }

--- a/apps/web/src/hooks/use-navigation.ts
+++ b/apps/web/src/hooks/use-navigation.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react'
+
+import type { Navigation } from '@/configs/layout-navigations'
+
+import {
+  getNavigations,
+  getTeamNavigations,
+} from '@/configs/layout-navigations'
+
+interface NavigationResult {
+  currentNavigation: Navigation | undefined
+  isTeamPage: boolean
+}
+
+/**
+ * Use navigation Hook - optimized.
+ * Determines the current navigation based on the pathname.
+ * @param pathname - The current pathname.
+ * @returns The current navigation and whether the user is on a team page.
+ */
+export const useNavigation = (pathname: string): NavigationResult => {
+  const teamId = useMemo(() => pathname.split('/')[2], [pathname])
+
+  return useMemo(() => {
+    if (teamId) {
+      const teamNavigations = getTeamNavigations({ teamId })
+      const currentNavigation = teamNavigations.find(
+        (nav) => nav.href === pathname,
+      )
+      return { currentNavigation, isTeamPage: true }
+    }
+
+    const defaultNavigations = getNavigations()
+    const currentNavigation = defaultNavigations.find(
+      (nav) => nav.href === pathname,
+    )
+    return { currentNavigation, isTeamPage: false }
+  }, [pathname, teamId])
+}

--- a/packages/api/src/routers/teams.ts
+++ b/packages/api/src/routers/teams.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
 
 import { db, eq } from '@buildit/db'
 import { teamTable, workspaceTable } from '@buildit/db/schema'
@@ -26,6 +27,18 @@ export const teamRouter = createRouter({
     })
     return teams
   }),
+  get_team_by_teamId: protectedProcedure
+    .input(z.object({ teamId: z.string() }))
+    .query(async ({ input }) => {
+      const team = await db.query.teamTable.findFirst({
+        where: eq(teamTable.teamId, input.teamId),
+        with: {
+          workspace: true,
+          user: true,
+        },
+      })
+      return team
+    }),
   create_team: protectedProcedure
     .input(CreateTeamFormSchema)
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
### Description
This pull request extends the dashboard header functionality to display the correct title for team pages.

### Key Changes
- Added support for team pages by maintaining them in an array.
- Introduced the `useNavigation` hook to dynamically determine the current navigation based on the page.
- Optimized the `Header` component by memoizing key values (`teamId`, `title`, `HeaderIcon`) and reducing redundant code in the JSX.
- Added api `get_team_by_teamId` to fetch the team details and use team name in the header title