### PR TITLE
feat(project-modal): Implement functionality to create project

### DIFF
--- a/apps/web/src/app/(dashboard)/projects/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/projects/page-client.tsx
@@ -10,6 +10,7 @@ import { Sidebar, SidebarContent, SidebarHeader } from '@buildit/ui/sidebar'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@buildit/ui/tabs'
 
 import Header from '@/components/layout/header'
+import { NewProjectModal } from '@/components/modals/new-project-modal'
 import FilterMenu from '@/components/projects/filter-menu'
 import ProjectLists from '@/components/projects/project-lists'
 import DisplayMenu from '@/components/ui/display-menu'
@@ -29,11 +30,12 @@ export default function ProjectsClientPage(): JSX.Element {
       <div className='h-full flex flex-col gap-2'>
         <Header>
           <div className='flex items-center gap-2'>
-            {/* TODO: Add a Create Project modal to create project */}
-            <Button variant={'secondary'} size={'sm'} className='h-7'>
-              <Icons.plus className='size-4 text-sub mr-1' />
-              Create project
-            </Button>
+            <NewProjectModal>
+              <Button variant={'secondary'} size={'sm'} className='h-7'>
+                <Icons.plus className='size-4 text-sub mr-1' />
+                Create project
+              </Button>
+            </NewProjectModal>
             <Separator orientation='vertical' className='h-5 ml-1' />
             <Button
               variant={'ghost'}

--- a/apps/web/src/components/forms/new-issue-form.tsx
+++ b/apps/web/src/components/forms/new-issue-form.tsx
@@ -10,15 +10,14 @@ import { Avatar, AvatarFallback, AvatarImage } from '@buildit/ui/avatar'
 import { Form, FormControl, FormField, FormItem } from '@buildit/ui/form'
 import { Input } from '@buildit/ui/input'
 
-import { priorityOptions, statusOptions } from '@/configs/filter-settings'
-
 import {
   ComboBox,
   ComboBoxContent,
   ComboBoxItem,
   ComboBoxTrigger,
-} from '../ui/combo-box'
-import { Icons } from '../ui/icons'
+} from '@/components/ui/combo-box'
+import { Icons } from '@/components/ui/icons'
+import { priorityOptions, statusOptions } from '@/configs/filter-settings'
 
 const defaultEditorValue = [
   {

--- a/apps/web/src/components/modals/new-issue-modal.tsx
+++ b/apps/web/src/components/modals/new-issue-modal.tsx
@@ -134,7 +134,7 @@ export const NewIssueModal = ({ children }: { children: React.ReactNode }) => {
               </ComboBoxContent>
             </ComboBox>
           ) : (
-            <p className='text-sm px-1.5 py-0.5 border rounded-md'>
+            <p className='text-sm px-1.5 py-0.5 border rounded-md select-none'>
               {team.teamId}
             </p>
           )}

--- a/apps/web/src/components/modals/new-issue-modal.tsx
+++ b/apps/web/src/components/modals/new-issue-modal.tsx
@@ -26,7 +26,6 @@ import {
   ModalHeader,
   ModalTitle,
   ModalTrigger,
-  VisuallyHide,
 } from '@/components/ui/modal'
 import { api } from '@/lib/trpc/react'
 
@@ -115,9 +114,7 @@ export const NewIssueModal = ({ children }: { children: React.ReactNode }) => {
     <Modal open={open} onOpenChange={setOpen}>
       <ModalTrigger asChild>{children}</ModalTrigger>
       <ModalContent>
-        <VisuallyHide>
-          <ModalTitle>Create Issue</ModalTitle>
-        </VisuallyHide>
+        <ModalTitle className='sr-only'>Create Issue</ModalTitle>
         <ModalHeader name='New issue'>
           {allTeams.length > 1 ? (
             <ComboBox open={openTeam} onOpenChange={setOpenTeam}>

--- a/apps/web/src/components/modals/new-project-modal.tsx
+++ b/apps/web/src/components/modals/new-project-modal.tsx
@@ -3,6 +3,14 @@
 import React, { useEffect, useState } from 'react'
 
 import type { TTeam } from '@buildit/utils/types'
+import type { CreateProjectPayload } from '@buildit/utils/validations'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+import { Button } from '@buildit/ui/button'
+import { toast } from '@buildit/ui/toast'
+import { CreateProjectSchema } from '@buildit/utils/validations'
 
 import NewProjectForm from '@/components/forms/new-project-form'
 import {
@@ -14,6 +22,7 @@ import {
 import {
   Modal,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalTitle,
   ModalTrigger,
@@ -37,6 +46,46 @@ export const NewProjectModal = ({
       setTeam(allTeams[0])
     }
   }, [allTeams])
+
+  const form = useForm<CreateProjectPayload>({
+    resolver: zodResolver(CreateProjectSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      status: 'planned',
+      priority: 'no priority',
+    },
+  })
+
+  const onSubmit = (values: CreateProjectPayload) => {
+    const localContent = localStorage.getItem('editorContent')
+    const descriptionContent = localContent
+
+    if (!team) {
+      toast({
+        variant: 'destructive',
+        title: 'Something went wrong!',
+        description: 'Team not found',
+      })
+      return
+    }
+
+    // Add mutation here
+
+    localStorage.removeItem('editorContent')
+    form.reset()
+    setOpen(!open)
+  }
+
+  const handleSubmit = form.handleSubmit(onSubmit, (errors) => {
+    const error = errors.name?.message
+    if (error) {
+      toast({
+        title: error,
+        description: 'Please enter a title before submitting',
+      })
+    }
+  })
 
   if (!allTeams || !team) return null
 
@@ -69,7 +118,12 @@ export const NewProjectModal = ({
             </p>
           )}
         </ModalHeader>
-        <NewProjectForm team={team} onOpenChange={setOpen} />
+        <NewProjectForm form={form} team={team} />
+        <ModalFooter className='pt-2'>
+          <Button size={'sm'} onClick={handleSubmit}>
+            Create project
+          </Button>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   )

--- a/apps/web/src/components/modals/new-project-modal.tsx
+++ b/apps/web/src/components/modals/new-project-modal.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
+import type { TTeam } from '@buildit/utils/types'
+
+import NewProjectForm from '@/components/forms/new-project-form'
 import {
   ComboBox,
   ComboBoxContent,
@@ -14,39 +17,40 @@ import {
   ModalHeader,
   ModalTitle,
   ModalTrigger,
-  VisuallyHide,
 } from '@/components/ui/modal'
 import { api } from '@/lib/trpc/react'
-
-import NewProjectForm from '../forms/new-project-form'
 
 export const NewProjectModal = ({
   children,
 }: {
   children: React.ReactNode
 }) => {
-  const { data: teams, isLoading } = api.team.get_teams.useQuery()
+  const { data: allTeams } = api.team.get_teams.useQuery()
 
   const [open, setOpen] = React.useState(false)
   const [openTeam, setOpenTeam] = React.useState(false)
 
-  const [team, setTeam] = React.useState(teams?.[0])
+  const [team, setTeam] = useState<TTeam | undefined>(undefined)
 
-  if (isLoading) return <></>
+  useEffect(() => {
+    if (allTeams?.length) {
+      setTeam(allTeams[0])
+    }
+  }, [allTeams])
+
+  if (!allTeams || !team) return null
 
   return (
     <Modal open={open} onOpenChange={setOpen}>
       <ModalTrigger asChild>{children}</ModalTrigger>
       <ModalContent>
-        <VisuallyHide>
-          <ModalTitle>Create Project</ModalTitle>
-        </VisuallyHide>
+        <ModalTitle className='sr-only'>Create Project</ModalTitle>
         <ModalHeader name='New project'>
-          {teams && teams.length > 1 ? (
+          {allTeams.length > 1 ? (
             <ComboBox open={openTeam} onOpenChange={setOpenTeam}>
-              <ComboBoxTrigger>{team?.name}</ComboBoxTrigger>
+              <ComboBoxTrigger>{team.name}</ComboBoxTrigger>
               <ComboBoxContent className='w-[200px]'>
-                {teams.map((team) => (
+                {allTeams.map((team) => (
                   <ComboBoxItem
                     key={team.id}
                     onSelect={() => {
@@ -60,7 +64,9 @@ export const NewProjectModal = ({
               </ComboBoxContent>
             </ComboBox>
           ) : (
-            <p className='text-sm'>{team?.name}</p>
+            <p className='text-sm px-1.5 py-0.5 border rounded-md select-none'>
+              {team.teamId}
+            </p>
           )}
         </ModalHeader>
         <NewProjectForm team={team} onOpenChange={setOpen} />

--- a/apps/web/src/components/modals/new-project-modal.tsx
+++ b/apps/web/src/components/modals/new-project-modal.tsx
@@ -57,6 +57,22 @@ export const NewProjectModal = ({
     },
   })
 
+  const mutation = api.project.create_project.useMutation({
+    onSuccess: ({ message }) => {
+      toast({
+        title: 'Project created',
+        description: message,
+      })
+    },
+    onError: ({ message }) => {
+      toast({
+        variant: 'destructive',
+        title: 'Something went wrong!',
+        description: message,
+      })
+    },
+  })
+
   const onSubmit = (values: CreateProjectPayload) => {
     const localContent = localStorage.getItem('editorContent')
     const descriptionContent = localContent
@@ -70,7 +86,11 @@ export const NewProjectModal = ({
       return
     }
 
-    // Add mutation here
+    mutation.mutate({
+      ...values,
+      description: descriptionContent,
+      teamId: team.id,
+    })
 
     localStorage.removeItem('editorContent')
     form.reset()
@@ -79,6 +99,7 @@ export const NewProjectModal = ({
 
   const handleSubmit = form.handleSubmit(onSubmit, (errors) => {
     const error = errors.name?.message
+
     if (error) {
       toast({
         title: error,

--- a/apps/web/src/components/ui/modal.tsx
+++ b/apps/web/src/components/ui/modal.tsx
@@ -68,7 +68,7 @@ export const ModalHeader = ({
       <div className='flex items-center space-x-1'>
         {children}
         <Icons.chevronRight className='h-4 w-4 text-soft' />
-        <p className='text-sm'>{name}</p>
+        <p className='text-sm select-none'>{name}</p>
       </div>
       <div className='flex items-center space-x-2'>
         <button

--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server'
 import { db, eq } from '@buildit/db'
 import { projectTable } from '@buildit/db/schema'
 import {
-  CreateProjectSchema,
+  CreateProjectInputSchema,
   DeleteProjectSchema,
 } from '@buildit/utils/validations'
 
@@ -20,7 +20,7 @@ export const projectRouter = createRouter({
     return projects
   }),
   create_project: protectedProcedure
-    .input(CreateProjectSchema)
+    .input(CreateProjectInputSchema)
     .mutation(async ({ input, ctx }) => {
       if (!input.teamId) {
         throw new TRPCError({
@@ -28,11 +28,17 @@ export const projectRouter = createRouter({
           message: 'Team ID is required',
         })
       }
+
       await db.insert(projectTable).values({
-        name: input.projectName,
+        name: input.name,
+        description: input.description,
+        status: input.status,
+        priority: input.priority,
+        leadId: input.leadId === '' ? null : (input.leadId ?? null),
         teamId: input.teamId,
         admin: ctx.user.id,
       })
+
       return { message: 'Project created successfully' }
     }),
   delete_project: protectedProcedure

--- a/packages/db/drizzle/0003_furry_nocturne.sql
+++ b/packages/db/drizzle/0003_furry_nocturne.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `project_new` (
+  `id` TEXT PRIMARY KEY NOT NULL,
+  `name` TEXT NOT NULL,
+  `description` TEXT,
+  `status` TEXT,
+  `priority` TEXT,
+  `admin` TEXT NOT NULL,
+  `leadId` TEXT,
+  `createdAt` INTEGER DEFAULT (CURRENT_TIMESTAMP),
+  `updatedAt` INTEGER DEFAULT (CURRENT_TIMESTAMP),
+  `teamId` TEXT NOT NULL,
+  FOREIGN KEY (`admin`) REFERENCES `user`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  FOREIGN KEY (`leadId`) REFERENCES `user`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  FOREIGN KEY (`teamId`) REFERENCES `team`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);--> statement-breakpoint
+
+PRAGMA foreign_keys=off;--> statement-breakpoint
+INSERT INTO `project_new` SELECT id, name, null as description, null as status, null as priority, admin, null as leadId, createdAt, updatedAt, teamId FROM `project`;--> statement-breakpoint
+DROP TABLE `project`;--> statement-breakpoint
+ALTER TABLE `project_new` RENAME TO `project`;--> statement-breakpoint
+PRAGMA foreign_keys=on;

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,773 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3bdce46f-f158-4ff0-8980-cb427a362ecc",
+  "prevId": "3d11e05c-1170-4377-b24f-68f66241b944",
+  "tables": {
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_codes_user_id_user_id_fk": {
+          "name": "email_verification_codes_user_id_user_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "oauth_account": {
+      "name": "oauth_account",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_account_user_id_user_id_fk": {
+          "name": "oauth_account_user_id_user_id_fk",
+          "tableFrom": "oauth_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_account_provider_id_provider_user_id_pk": {
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ],
+          "name": "oauth_account_provider_id_provider_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "waitlist": {
+      "name": "waitlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'waiting'"
+        }
+      },
+      "indexes": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "issue": {
+      "name": "issue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporterId": {
+          "name": "reporterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "issue_issueId_unique": {
+          "name": "issue_issueId_unique",
+          "columns": [
+            "issueId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issue_reporterId_user_id_fk": {
+          "name": "issue_reporterId_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_assigneeId_user_id_fk": {
+          "name": "issue_assigneeId_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_workspaceId_workspace_id_fk": {
+          "name": "issue_workspaceId_workspace_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_teamId_team_id_fk": {
+          "name": "issue_teamId_team_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_projectId_project_id_fk": {
+          "name": "issue_projectId_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "project": {
+      "name": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leadId": {
+          "name": "leadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_admin_user_id_fk": {
+          "name": "project_admin_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_leadId_user_id_fk": {
+          "name": "project_leadId_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "leadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_teamId_team_id_fk": {
+          "name": "project_teamId_team_id_fk",
+          "tableFrom": "project",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issueCounter": {
+          "name": "issueCounter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "admin": {
+          "name": "admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_teamId_unique": {
+          "name": "team_teamId_unique",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_admin_user_id_fk": {
+          "name": "team_admin_user_id_fk",
+          "tableFrom": "team",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_workspaceId_workspace_id_fk": {
+          "name": "team_workspaceId_workspace_id_fk",
+          "tableFrom": "team",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "workspace": {
+      "name": "workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_userId_user_id_fk": {
+          "name": "workspace_userId_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1726586121479,
       "tag": "0002_slimy_raza",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1731215369824,
+      "tag": "0003_furry_nocturne",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/project/project.ts
+++ b/packages/db/src/schema/project/project.ts
@@ -10,15 +10,27 @@ export const projectTable = sqliteTable('project', {
     .primaryKey()
     .$defaultFn(() => nanoid()),
   name: text('name').notNull(),
+  description: text('description', { mode: 'json' }),
+  status: text('status', {
+    enum: ['backlog', 'planned', 'in progress', 'completed', 'canceled'],
+  }),
+  priority: text('priority', {
+    enum: ['low', 'medium', 'high', 'urgent', 'no priority'],
+  }),
+  admin: text('admin')
+    .notNull()
+    .references(() => userTable.id, {
+      onDelete: 'cascade',
+    }),
+  leadId: text('leadId').references(() => userTable.id, {
+    onDelete: 'cascade',
+  }),
   createdAt: integer('createdAt', { mode: 'timestamp_ms' }).default(
     sql`(CURRENT_TIMESTAMP)`,
   ),
   updatedAt: integer('updatedAt', { mode: 'timestamp_ms' }).default(
     sql`(CURRENT_TIMESTAMP)`,
   ),
-  admin: text('admin')
-    .notNull()
-    .references(() => userTable.id, { onDelete: 'cascade' }),
   teamId: text('teamId')
     .notNull()
     .references(() => teamTable.id, { onDelete: 'cascade' }),
@@ -27,6 +39,10 @@ export const projectTable = sqliteTable('project', {
 export const projectRelations = relations(projectTable, ({ one }) => ({
   user: one(userTable, {
     fields: [projectTable.admin],
+    references: [userTable.id],
+  }),
+  lead: one(userTable, {
+    fields: [projectTable.leadId],
     references: [userTable.id],
   }),
   team: one(teamTable, {

--- a/packages/db/src/schema/team/team.ts
+++ b/packages/db/src/schema/team/team.ts
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 
 import { userTable } from '../auth/user'
 import { issueTable } from '../issue'
+import { projectTable } from '../project'
 import { workspaceTable } from '../workspace'
 
 export const teamTable = sqliteTable('team', {
@@ -37,4 +38,5 @@ export const teamRelations = relations(teamTable, ({ one, many }) => ({
     references: [workspaceTable.id],
   }),
   issue: many(issueTable),
+  projects: many(projectTable),
 }))

--- a/packages/utils/src/validations/projects/index.ts
+++ b/packages/utils/src/validations/projects/index.ts
@@ -11,13 +11,17 @@ const PRIORITY = ['no priority', 'urgent', 'high', 'medium', 'low'] as const
 
 export const CreateProjectSchema = z.object({
   name: z.string().min(1, { message: 'Name is required.' }),
-  description: z.string(),
+  description: z.nullable(z.string()),
   status: z.enum(STATUS),
   priority: z.enum(PRIORITY),
   leadId: z.optional(z.nullable(z.string())),
 })
 
 export type CreateProjectPayload = z.infer<typeof CreateProjectSchema>
+
+export const CreateProjectInputSchema = CreateProjectSchema.extend({
+  teamId: z.string(),
+})
 
 export const DeleteProjectSchema = z.object({
   projectId: z.string(),

--- a/packages/utils/src/validations/projects/index.ts
+++ b/packages/utils/src/validations/projects/index.ts
@@ -1,9 +1,23 @@
 import { z } from 'zod'
 
+const STATUS = [
+  'backlog',
+  'planned',
+  'in progress',
+  'completed',
+  'canceled',
+] as const
+const PRIORITY = ['no priority', 'urgent', 'high', 'medium', 'low'] as const
+
 export const CreateProjectSchema = z.object({
-  projectName: z.string().min(3, 'Project name must be at least 3 characters.'),
-  teamId: z.string().optional(),
+  name: z.string().min(1, { message: 'Name is required.' }),
+  description: z.string(),
+  status: z.enum(STATUS),
+  priority: z.enum(PRIORITY),
+  leadId: z.optional(z.nullable(z.string())),
 })
+
+export type CreateProjectPayload = z.infer<typeof CreateProjectSchema>
 
 export const DeleteProjectSchema = z.object({
   projectId: z.string(),


### PR DESCRIPTION
### Description
This pull request adds a new functionality to create a `project` within a modal with `name`, `description`, `status`, `priority` and `lead` attributes.

### Key changes

- Modified `Project` table in database.
- Added `api` to create a project.
- Added a `interactive modal` to create a project with the above `attributes` or `properties`.