### PR TITLE
feat(empty-state): add empty state for projects page

### DIFF
--- a/apps/web/src/components/issues/issue-list.tsx
+++ b/apps/web/src/components/issues/issue-list.tsx
@@ -5,11 +5,10 @@ import { useEffect, useMemo, useState } from 'react'
 import type { FilterQuery } from '@/lib/store/filter-store'
 import type { TIssue } from '@buildit/utils/types'
 
+import IssuesGroup from '@/components/issues/issue-group'
+import IssueItem from '@/components/issues/issue-item'
 import EmptyState from '@/components/ui/empty-state'
 import { useFilterStore } from '@/hooks/store'
-
-import IssuesGroup from './issue-group'
-import IssueItem from './issue-item'
 
 interface FilterDetail {
   key: string

--- a/apps/web/src/components/projects/project-lists.tsx
+++ b/apps/web/src/components/projects/project-lists.tsx
@@ -1,4 +1,5 @@
 import ProjectItem from '@/components/projects/project-item'
+import EmptyState from '@/components/ui/empty-state'
 import { api } from '@/lib/trpc/react'
 
 /**
@@ -11,14 +12,7 @@ export default function ProjectLists() {
   return (
     <>
       {projects?.length === 0 ? (
-        <div className='flex h-1/2 w-full flex-col items-center justify-center space-y-4 rounded-lg'>
-          <div className='flex flex-col items-center'>
-            <h1 className='font-cal text-strong text-xl'>No project found</h1>
-            <p className='text-sm text-sub'>
-              There aren&apos;t any project at the moment!{' '}
-            </p>
-          </div>
-        </div>
+        <EmptyState id='projects' />
       ) : (
         <ul>
           {projects?.map((project) => (

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -24,7 +24,7 @@ export default function EmptyState({ id }: EmptyStateProps): JSX.Element {
   const Icon = Icons[icon as keyof typeof Icons]
 
   return (
-    <div className='w-full flex justify-center mt-24'>
+    <div className='w-full h-full flex justify-center items-center'>
       <div className='flex flex-col items-start p-4'>
         <div className='border rounded-md mb-2'>
           <Icon className='size-5 text-sub m-2' />

--- a/apps/web/src/configs/empty-state.tsx
+++ b/apps/web/src/configs/empty-state.tsx
@@ -27,9 +27,8 @@ export const emptyStateContent: TEmptyStateContent = {
   },
   projects: {
     icon: 'hexagon',
-    title: 'No Projects Yet',
-    description:
-      'Projects help you organize your work. Create a new project to start tracking progress and collaborating with your team.',
+    title: 'No Projects Yet!',
+    description: `Projects serve as the backbone of your work organization, enabling you to structure tasks, set milestones, and monitor progress effectively. By creating a project, you can centralize your team's efforts, ensure clear communication, and track outcomes seamlessly.`,
     primary: (
       <NewProjectModal>
         <Button variant={'default'} size={'sm'} className='h-7'>


### PR DESCRIPTION
### Description:
This pull request implements an `empty` state for the list of `projects`, if there is no project present. The empty state should properly describes the user regarding the function of this page, with call-to-action button.