### PR TITLE
feat(project-display-menu): Add Display Menu and Create Project from Groups Tab

### DIFF
--- a/apps/web/src/app/(dashboard)/(my-issues)/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/(my-issues)/page-client.tsx
@@ -17,6 +17,10 @@ import DisplayMenu from '@/components/ui/display-menu'
 import FilterMenu from '@/components/ui/filter-menu'
 import FloatingToolbar from '@/components/ui/floating-toolbar'
 import { Icons } from '@/components/ui/icons'
+import {
+  IssuesDisplayProperties,
+  IssuesGroupingOptions,
+} from '@/configs/display-settings'
 import { useFilterStore } from '@/hooks/store'
 import { usePrioritySummary } from '@/hooks/use-priority-summary'
 import { useStatusSummary } from '@/hooks/use-status-summary'
@@ -128,7 +132,10 @@ export default function MyIssuesClientPage(): JSX.Element {
       </Header>
       <div className='flex justify-between items-center'>
         <FilterMenu />
-        <DisplayMenu />
+        <DisplayMenu
+          groupingOptions={IssuesGroupingOptions}
+          allDisplayProperties={IssuesDisplayProperties}
+        />
       </div>
       <div className='relative flex h-full w-full overflow-hidden'>
         <div

--- a/apps/web/src/app/(dashboard)/projects/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/projects/page-client.tsx
@@ -16,6 +16,10 @@ import FilterMenu from '@/components/projects/filter-menu'
 import ProjectLists from '@/components/projects/project-lists'
 import DisplayMenu from '@/components/ui/display-menu'
 import { Icons } from '@/components/ui/icons'
+import {
+  ProjectsDisplayProperties,
+  ProjectsGroupingOptions,
+} from '@/configs/display-settings'
 import { useLeadsSummary } from '@/hooks/use-lead-summary'
 import { usePrioritySummary } from '@/hooks/use-priority-summary'
 import { useStatusSummary } from '@/hooks/use-status-summary'
@@ -156,7 +160,10 @@ export default function ProjectsClientPage(): JSX.Element {
       </Header>
       <div className='flex justify-between items-center'>
         <FilterMenu />
-        <DisplayMenu />
+        <DisplayMenu
+          groupingOptions={ProjectsGroupingOptions}
+          allDisplayProperties={ProjectsDisplayProperties}
+        />
       </div>
       <div className='relative flex h-full w-full overflow-hidden'>
         <div

--- a/apps/web/src/components/issues/issue-list.tsx
+++ b/apps/web/src/components/issues/issue-list.tsx
@@ -85,7 +85,9 @@ export default function IssueList({
     if (groupBy === 'No Grouping') return { '': filtered }
 
     return filtered.reduce<Record<string, TIssue[]>>((groups, issue) => {
-      const groupKey = (issue[groupBy] as string) || 'Uncategorized'
+      const groupKey =
+        (issue[groupBy as keyof TIssue] as string) || 'Uncategorized'
+
       if (!groups[groupKey]) groups[groupKey] = []
       groups[groupKey].push(issue)
       return groups

--- a/apps/web/src/components/modals/new-project-modal.tsx
+++ b/apps/web/src/components/modals/new-project-modal.tsx
@@ -31,8 +31,10 @@ import { api } from '@/lib/trpc/react'
 
 export const NewProjectModal = ({
   children,
+  defaultValues = {},
 }: {
   children: React.ReactNode
+  defaultValues?: Partial<CreateProjectPayload>
 }) => {
   const { data: allTeams } = api.team.get_teams.useQuery()
 
@@ -54,6 +56,7 @@ export const NewProjectModal = ({
       description: '',
       status: 'planned',
       priority: 'no priority',
+      ...defaultValues,
     },
   })
 

--- a/apps/web/src/components/projects/project-card.tsx
+++ b/apps/web/src/components/projects/project-card.tsx
@@ -10,6 +10,7 @@ import {
   priorityOptions,
   statusOptions,
 } from '@/configs/project-filter-settings'
+import { useFilterStore } from '@/hooks/store'
 
 interface ProjectCardProps {
   project: Omit<TProject, 'issues' | 'teams'>
@@ -30,6 +31,8 @@ export default function ProjectCard({
   isFirst,
   isLast,
 }: ProjectCardProps): JSX.Element {
+  const { displayProperties } = useFilterStore()
+
   const priorityIconName = priorityOptions.find(
     (priority) => priority.value === project.priority,
   )?.icon
@@ -39,6 +42,9 @@ export default function ProjectCard({
 
   const PriorityIcon = Icons[priorityIconName as keyof typeof Icons]
   const StatusIcon = Icons[statusIconName as keyof typeof Icons]
+
+  const renderDisplayProperty = (property: string, content: React.ReactNode) =>
+    displayProperties.includes(property) ? content : null
 
   return (
     <div
@@ -63,55 +69,63 @@ export default function ProjectCard({
           </span>
         </div>
         <div className='ml-auto flex items-center space-x-4 flex-shrink-0'>
-          <Tooltip>
-            <TooltipTrigger>
-              <PriorityIcon className='size-4 text-sub' />
-            </TooltipTrigger>
-            <TooltipContent className='capitalize'>
-              Priority: {project.priority}
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger>
-              <StatusIcon className='size-4 text-sub' />
-            </TooltipTrigger>
-
-            <TooltipContent className='capitalize'>
-              Status: {project.status}
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            {project.leadId ? (
-              project.lead && (
+          {renderDisplayProperty(
+            'priority',
+            <Tooltip>
+              <TooltipTrigger>
+                <PriorityIcon className='size-4 text-sub' />
+              </TooltipTrigger>
+              <TooltipContent className='capitalize'>
+                Priority: {project.priority}
+              </TooltipContent>
+            </Tooltip>,
+          )}
+          {renderDisplayProperty(
+            'status',
+            <Tooltip>
+              <TooltipTrigger>
+                <StatusIcon className='size-4 text-sub' />
+              </TooltipTrigger>
+              <TooltipContent className='capitalize'>
+                Status: {project.status}
+              </TooltipContent>
+            </Tooltip>,
+          )}
+          {renderDisplayProperty(
+            'lead',
+            <Tooltip>
+              {project.leadId ? (
+                project.lead && (
+                  <>
+                    <TooltipTrigger>
+                      <Avatar className='size-5'>
+                        <AvatarImage
+                          src={project.lead.image ?? ''}
+                          alt={project.lead.name ?? ''}
+                        />
+                        <AvatarFallback>
+                          {project.lead.name?.charAt(0)}
+                        </AvatarFallback>
+                      </Avatar>
+                    </TooltipTrigger>
+                    <TooltipContent align='end'>
+                      Lead: {project.lead.name}
+                    </TooltipContent>
+                  </>
+                )
+              ) : (
                 <>
                   <TooltipTrigger>
-                    <Avatar className='size-5'>
-                      <AvatarImage
-                        src={project.lead.image ?? ''}
-                        alt={project.lead.name ?? ''}
-                      />
-                      <AvatarFallback>
-                        {project.lead.name?.charAt(0)}
-                      </AvatarFallback>
-                    </Avatar>
+                    <Icons.userCircle2
+                      className='size-5 text-soft'
+                      aria-label='Unassigned'
+                    />
                   </TooltipTrigger>
-                  <TooltipContent align='end'>
-                    Lead: {project.lead.name}
-                  </TooltipContent>
+                  <TooltipContent align='end'>Lead: Unassigned</TooltipContent>
                 </>
-              )
-            ) : (
-              <>
-                <TooltipTrigger>
-                  <Icons.userCircle2
-                    className='size-5 text-soft'
-                    aria-label='Unassigned'
-                  />
-                </TooltipTrigger>
-                <TooltipContent align='end'>Lead: Unassigned</TooltipContent>
-              </>
-            )}
-          </Tooltip>
+              )}
+            </Tooltip>,
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/projects/project-group.tsx
+++ b/apps/web/src/components/projects/project-group.tsx
@@ -37,7 +37,6 @@ export default function ProjectGroup({
     (priorityOptions.find((priority) => priority.value === group) && 'priority')
 
   const groupData = getGroupData(group)
-  console.log('groupData', groupData)
 
   if (!groupData) return <></>
 

--- a/apps/web/src/components/projects/project-group.tsx
+++ b/apps/web/src/components/projects/project-group.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@buildit/ui/button'
 
-import { NewIssueModal } from '@/components/modals/new-issue-modal'
+import { NewProjectModal } from '@/components/modals/new-project-modal'
 import { Icons } from '@/components/ui/icons'
 import {
   priorityOptions,
@@ -37,6 +37,7 @@ export default function ProjectGroup({
     (priorityOptions.find((priority) => priority.value === group) && 'priority')
 
   const groupData = getGroupData(group)
+  console.log('groupData', groupData)
 
   if (!groupData) return <></>
 
@@ -53,7 +54,7 @@ export default function ProjectGroup({
           <p className='text-sm text-soft'>{count}</p>
         </div>
 
-        <NewIssueModal
+        <NewProjectModal
           defaultValues={{
             [groupType as string]: group,
           }}
@@ -65,7 +66,7 @@ export default function ProjectGroup({
           >
             <Icons.plus className='size-4 text-sub' />
           </Button>
-        </NewIssueModal>
+        </NewProjectModal>
       </div>
     </>
   )

--- a/apps/web/src/components/projects/project-group.tsx
+++ b/apps/web/src/components/projects/project-group.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Button } from '@buildit/ui/button'
+
+import { NewIssueModal } from '@/components/modals/new-issue-modal'
+import { Icons } from '@/components/ui/icons'
+import {
+  priorityOptions,
+  statusOptions,
+} from '@/configs/project-filter-settings'
+
+/**
+ * The Project Group component to display the group of Projects.
+ * @param props The component properties.
+ * @param props.group The group to display.
+ * @param props.count The number of issue in this group
+ * @returns JSX component.
+ */
+export default function ProjectGroup({
+  group,
+  count,
+}: {
+  group: string
+  count: number
+}): JSX.Element {
+  // Retrieve either status or priority group by the value
+  const getGroupData = (group: string) => {
+    return (
+      statusOptions.find((status) => status.value === group) ??
+      priorityOptions.find((priority) => priority.value === group)
+    )
+  }
+
+  // Determine the group type
+  const groupType =
+    (statusOptions.find((status) => status.value === group) && 'status') ??
+    (priorityOptions.find((priority) => priority.value === group) && 'priority')
+
+  const groupData = getGroupData(group)
+
+  if (!groupData) return <></>
+
+  const Icon = Icons[groupData.icon as keyof typeof Icons]
+
+  return (
+    <>
+      <div className='flex items-center justify-between pr-2.5 mb-2'>
+        <div className='flex items-center gap-2 bg-weak/50 px-3 py-1 min-w-32 border border-soft/50 rounded-md'>
+          <Icon className='size-4 text-sub' />
+          <h2 className='font-medium text-sm text-surface'>
+            {groupData.label}
+          </h2>
+          <p className='text-sm text-soft'>{count}</p>
+        </div>
+
+        <NewIssueModal
+          defaultValues={{
+            [groupType as string]: group,
+          }}
+        >
+          <Button
+            variant={'ghost'}
+            size={'icon'}
+            className='size-7 rounded bg-weak/50 border border-soft/50'
+          >
+            <Icons.plus className='size-4 text-sub' />
+          </Button>
+        </NewIssueModal>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/projects/project-lists.tsx
+++ b/apps/web/src/components/projects/project-lists.tsx
@@ -1,8 +1,12 @@
+import { useMemo } from 'react'
+
 import type { TProject } from '@buildit/utils/types'
 
 import ProjectCard from '@/components/projects/project-card'
+import ProjectGroup from '@/components/projects/project-group'
 import ProjectItem from '@/components/projects/project-item'
 import EmptyState from '@/components/ui/empty-state'
+import { useFilterStore } from '@/hooks/store'
 
 /**
  * The project lists component. Lists all the projects.
@@ -15,13 +19,34 @@ export default function ProjectLists({
 }: {
   projects: TProject[] | undefined
 }): JSX.Element {
+  const { groupBy } = useFilterStore()
+
+  const filteredAndGroupedProjects = useMemo(() => {
+    if (!projects) return { '': [] }
+
+    // TODO: Implement the filter logic
+
+    if (groupBy === 'No Grouping') return { '': projects }
+
+    return projects.reduce<Record<string, TProject[]>>((groups, project) => {
+      const groupKey =
+        (project[groupBy as keyof TProject] as string) || 'Uncategorized'
+      if (!groups[groupKey]) groups[groupKey] = []
+      groups[groupKey].push(project)
+      return groups
+    }, {})
+  }, [projects, groupBy])
+
+  if (Object.values(filteredAndGroupedProjects).flat().length === 0) {
+    return <EmptyState id='projects' />
+  }
+
   return (
     <>
-      {projects?.length === 0 ? (
-        <EmptyState id='projects' />
-      ) : (
-        <ul>
-          {projects?.map((project, index) => (
+      {Object.entries(filteredAndGroupedProjects).map(([group, projects]) => (
+        <ul key={group}>
+          <ProjectGroup group={group} count={projects.length} />{' '}
+          {projects.map((project, index) => (
             <ProjectItem project={project} key={project.id}>
               <ProjectCard
                 project={project}
@@ -31,7 +56,7 @@ export default function ProjectLists({
             </ProjectItem>
           ))}
         </ul>
-      )}
+      ))}
     </>
   )
 }

--- a/apps/web/src/components/ui/display-menu.tsx
+++ b/apps/web/src/components/ui/display-menu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Badge } from '@buildit/ui/badge'
 import { Button } from '@buildit/ui/button'
@@ -13,22 +13,35 @@ import { Popover, PopoverContent, PopoverTrigger } from '@buildit/ui/popover'
 import { Separator } from '@buildit/ui/separator'
 
 import { Icons } from '@/components/ui/icons'
-import {
-  allDisplayProperties,
-  groupingOptions,
-} from '@/configs/display-settings'
 import { useFilterStore } from '@/hooks/store'
+
+interface DisplayMenuProps {
+  groupingOptions: { label: string; value: string }[]
+  allDisplayProperties: string[]
+}
 
 /**
  * The display menu component. It contains the grouping and ordering options.
+ * @param props The component props.
+ * @param props.groupingOptions The grouping options.
+ * @param props.allDisplayProperties The display properties.
  * @returns The display menu component.
  */
-export default function DisplayMenu() {
+export default function DisplayMenu({
+  groupingOptions,
+  allDisplayProperties,
+}: DisplayMenuProps): JSX.Element {
   const [open, setOpen] = useState(false)
   const [grouping, setGrouping] = useState('noGrouping')
 
   const { setGroupBy, displayProperties, setDisplayProperties } =
     useFilterStore()
+
+  useEffect(() => {
+    allDisplayProperties.forEach((property) => {
+      setDisplayProperties(property)
+    })
+  }, [allDisplayProperties, setDisplayProperties])
 
   const handleSelectGrouping = (group: string) => {
     setGroupBy(group)

--- a/apps/web/src/configs/display-settings.ts
+++ b/apps/web/src/configs/display-settings.ts
@@ -31,29 +31,6 @@ export const ProjectsGroupingOptions: DisplaySettings[] = [
   },
 ]
 
-export const orderingOptions: DisplaySettings[] = [
-  {
-    label: 'No ordering',
-    value: 'noOrdering',
-  },
-  {
-    label: 'Status',
-    value: 'status',
-  },
-  {
-    label: 'Priority',
-    value: 'priority',
-  },
-  {
-    label: 'Last updated',
-    value: 'lastUpdated',
-  },
-  {
-    label: 'Last created',
-    value: 'lastCreated',
-  },
-]
-
 export const IssuesDisplayProperties = [
   'priority',
   'id',

--- a/apps/web/src/configs/display-settings.ts
+++ b/apps/web/src/configs/display-settings.ts
@@ -2,7 +2,21 @@ import type { FilterSettings } from '@buildit/utils/types/configs'
 
 type DisplaySettings = Omit<FilterSettings, 'icon'>
 
-export const groupingOptions: DisplaySettings[] = [
+export const IssuesGroupingOptions: DisplaySettings[] = [
+  {
+    label: 'Status',
+    value: 'status',
+  },
+  {
+    label: 'Priority',
+    value: 'priority',
+  },
+  {
+    label: 'No grouping',
+    value: 'noGrouping',
+  },
+]
+export const ProjectsGroupingOptions: DisplaySettings[] = [
   {
     label: 'Status',
     value: 'status',
@@ -40,7 +54,7 @@ export const orderingOptions: DisplaySettings[] = [
   },
 ]
 
-export const allDisplayProperties = [
+export const IssuesDisplayProperties = [
   'priority',
   'id',
   'status',
@@ -48,3 +62,5 @@ export const allDisplayProperties = [
   'updated',
   'assignee',
 ]
+
+export const ProjectsDisplayProperties = ['status', 'priority', 'lead']

--- a/apps/web/src/configs/project-filter-settings.ts
+++ b/apps/web/src/configs/project-filter-settings.ts
@@ -34,7 +34,7 @@ export const statusOptions: FilterSettings[] = [
   {
     value: 'planned',
     label: 'Planned',
-    icon: 'todo',
+    icon: 'hexagon',
   },
   {
     value: 'in progress',

--- a/apps/web/src/lib/store/filter-store.ts
+++ b/apps/web/src/lib/store/filter-store.ts
@@ -1,5 +1,3 @@
-import type { TIssue } from '@buildit/utils/types'
-
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
@@ -39,8 +37,8 @@ export interface FilterStore {
     value: FilterCondition | FilterQuery,
   ) => void
   removeFilter: (type: string) => void
-  groupBy: keyof TIssue | 'No Grouping'
-  setGroupBy: (group: keyof TIssue | 'No Grouping') => void
+  groupBy: string
+  setGroupBy: (group: string) => void
   displayProperties: string[]
   setDisplayProperties: (property: string) => void
   selectedIssues: string[]

--- a/apps/web/src/lib/store/filter-store.ts
+++ b/apps/web/src/lib/store/filter-store.ts
@@ -3,8 +3,6 @@ import type { TIssue } from '@buildit/utils/types'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-import { allDisplayProperties } from '@/configs/display-settings'
-
 type Operator =
   | 'eq'
   | 'ne'
@@ -89,7 +87,7 @@ const createFilterStore = (pathname: string) =>
             groupBy: group,
           }))
         },
-        displayProperties: allDisplayProperties,
+        displayProperties: [''],
         setDisplayProperties: (property) => {
           set((state) => ({
             displayProperties: state.displayProperties.includes(property)

--- a/apps/web/src/lib/store/filter-store.ts
+++ b/apps/web/src/lib/store/filter-store.ts
@@ -49,64 +49,59 @@ export interface FilterStore {
 const createFilterStore = (pathname: string) =>
   create<FilterStore>()(
     persist(
-      (set) => ({
-        and: [],
-        setFilter: (type, operator, value) => {
-          set((state) => {
-            const newFilter = { [type]: { [operator]: value } }
-            return {
-              and: [...state.and, newFilter], // keep the existing filters and add the new one
-            }
-          })
-        },
-        updateFilter: (type, operator, value) => {
-          set((state) => {
-            const newFilter = { [type]: { [operator]: value } }
-            return {
-              and: state.and.map((filter) => {
-                if (filter[type]) {
-                  return newFilter // update the filter with the given type
-                }
-                return filter
-              }),
-            }
-          })
-        },
-        removeFilter: (type) => {
-          set((state) => {
-            return {
-              and: state.and.filter((filter) => !filter[type]), // remove the filter with the given type
-            }
-          })
-        },
-        groupBy: 'No Grouping',
-        setGroupBy: (group) => {
-          set(() => ({
-            groupBy: group,
-          }))
-        },
-        displayProperties: [''],
-        setDisplayProperties: (property) => {
-          set((state) => ({
-            displayProperties: state.displayProperties.includes(property)
-              ? state.displayProperties.filter((prop) => prop !== property)
-              : [...state.displayProperties, property],
-          }))
-        },
-        selectedIssues: [],
-        setSelectedIssues: (issueId) => {
-          set((state) => ({
-            selectedIssues: state.selectedIssues.includes(issueId)
-              ? state.selectedIssues.filter((id) => id !== issueId)
-              : [...state.selectedIssues, issueId],
-          }))
-        },
-        clearSelectedIssues: () => {
-          set(() => ({
-            selectedIssues: [],
-          }))
-        },
-      }),
+      (set) => {
+        const defaultDisplayProperties = pathname.includes('projects')
+          ? ['status', 'priority', 'lead']
+          : ['priority', 'id', 'status', 'created', 'updated', 'assignee']
+
+        return {
+          and: [],
+          setFilter: (type, operator, value) => {
+            set((state) => ({
+              and: [...state.and, { [type]: { [operator]: value } }],
+            }))
+          },
+          updateFilter: (type, operator, value) => {
+            set((state) => ({
+              and: state.and.map((filter) =>
+                filter[type] ? { [type]: { [operator]: value } } : filter,
+              ),
+            }))
+          },
+          removeFilter: (type) => {
+            set((state) => ({
+              and: state.and.filter((filter) => !filter[type]),
+            }))
+          },
+          groupBy: 'No Grouping',
+          setGroupBy: (group) => {
+            set(() => ({ groupBy: group }))
+          },
+          displayProperties: defaultDisplayProperties,
+          setDisplayProperties: (property) => {
+            set((state) => {
+              const currentProps = new Set(state.displayProperties)
+              if (currentProps.has(property)) {
+                currentProps.delete(property)
+              } else {
+                currentProps.add(property)
+              }
+              return { displayProperties: Array.from(currentProps) }
+            })
+          },
+          selectedIssues: [],
+          setSelectedIssues: (issueId) => {
+            set((state) => ({
+              selectedIssues: state.selectedIssues.includes(issueId)
+                ? state.selectedIssues.filter((id) => id !== issueId)
+                : [...state.selectedIssues, issueId],
+            }))
+          },
+          clearSelectedIssues: () => {
+            set(() => ({ selectedIssues: [] }))
+          },
+        }
+      },
       {
         name: `filter${pathname}`,
         partialize: (state) =>


### PR DESCRIPTION
### Description:
This pull request implements `display-menu` and create project from groups tab, with a particular property functionality. 

### Key changes:
- Added `display-menu` for projects page.
- Added `grouping-options`.
- Fixed default display properties not showing,
- Added create project from groups tab functionality.