### PR TITLE
feat(empty-state): add empty-state for teams page

### DIFF
--- a/apps/web/src/components/modals/new-team-modal.tsx
+++ b/apps/web/src/components/modals/new-team-modal.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 
-import { Button } from '@buildit/ui/button'
+import type { ReactNode } from 'react'
+
 import {
   Dialog,
   DialogContent,
@@ -13,19 +14,13 @@ import {
 } from '@buildit/ui/dialog'
 
 import NewTeamForm from '@/components/forms/new-team-form'
-import { Icons } from '@/components/ui/icons'
 
-export const NewTeamModal = () => {
+export const NewTeamModal = ({ children }: { children: ReactNode }) => {
   const [open, setOpen] = React.useState(false)
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button size={'sm'}>
-          <Icons.plus className='h-4 w-4 mr-2 text-white' />
-          New team
-        </Button>
-      </DialogTrigger>
+      <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>New Team</DialogTitle>

--- a/apps/web/src/components/teams/team-list.tsx
+++ b/apps/web/src/components/teams/team-list.tsx
@@ -1,15 +1,29 @@
 'use client'
 
-import { api } from '@/lib/trpc/react'
+import { toast } from '@buildit/ui/toast'
 
-import TeamItem from './team-item'
+import TeamItem from '@/components/teams/team-item'
+import EmptyState from '@/components/ui/empty-state'
+import { api } from '@/lib/trpc/react'
 
 /**
  * The team list component. Lists all the teams.
  * @returns JSX.Element
  */
 export default function TeamList(): JSX.Element {
-  const { data: allTeams } = api.team.get_teams.useQuery()
+  const { data: allTeams, error } = api.team.get_teams.useQuery()
+
+  if (allTeams?.length === 0) {
+    return <EmptyState id='teams' />
+  }
+
+  if (error) {
+    toast({
+      title: 'Error',
+      description: 'Failed to fetch teams',
+      variant: 'destructive',
+    })
+  }
   return (
     <div>{allTeams?.map((team) => <TeamItem key={team.id} team={team} />)}</div>
   )

--- a/apps/web/src/configs/empty-state.tsx
+++ b/apps/web/src/configs/empty-state.tsx
@@ -4,6 +4,7 @@ import { Button } from '@buildit/ui/button'
 
 import { NewIssueModal } from '@/components/modals/new-issue-modal'
 import { NewProjectModal } from '@/components/modals/new-project-modal'
+import { NewTeamModal } from '@/components/modals/new-team-modal'
 import { Icons } from '@/components/ui/icons'
 
 export const emptyStateContent: TEmptyStateContent = {
@@ -44,10 +45,12 @@ export const emptyStateContent: TEmptyStateContent = {
     description:
       'Teams allow you to collaborate effectively. Create a new team to start assigning roles and tasks.',
     primary: (
-      <Button variant={'default'} size={'sm'} className='h-7'>
-        <Icons.plus className='size-4  mr-1' />
-        Add team
-      </Button>
+      <NewTeamModal>
+        <Button variant={'default'} size={'sm'} className='h-7'>
+          <Icons.plus className='size-4 mr-1' />
+          Create team
+        </Button>
+      </NewTeamModal>
     ),
   },
   // Add more entries as needed...


### PR DESCRIPTION
### Description:
This pull request implements an `empty-state` for the list of teams, if there is no team present. The empty state should properly describes the user regarding the function of this page, with call-to-action button.