### PR TITLE
feat(issues-id): Add issue/[id] page

### DIFF
--- a/apps/web/src/app/(dashboard)/(my-issues)/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/(my-issues)/page-client.tsx
@@ -103,7 +103,7 @@ export default function MyIssuesClientPage(): JSX.Element {
   }
 
   return (
-    <div className='h-full flex flex-col gap-2'>
+    <div className='h-full flex flex-col gap-2 p-2'>
       <Header>
         <div className='flex items-center gap-2'>
           <NewIssueModal>

--- a/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { Sidebar } from '@buildit/ui/sidebar'
+import { Skeleton } from '@buildit/ui/skeleton'
+import { toast } from '@buildit/ui/toast'
 
 import Content from '@/components/issue/content'
 import Header from '@/components/layout/header'
@@ -18,10 +20,22 @@ export default function IssueClientPage({
   issueId: string
 }): JSX.Element {
   // Fetch the issue details using the ID
-  const { data: issue } = api.issues.get_issue_by_id.useQuery(
+  const {
+    data: issue,
+    isLoading,
+    error,
+  } = api.issues.get_issue_by_id.useQuery(
     { id: issueId },
     { enabled: !!issueId },
   )
+
+  if (error) {
+    toast({
+      title: 'Error',
+      description: `Failed to fetch issue - ${issueId}`,
+      variant: 'destructive',
+    })
+  }
 
   return (
     <div className='h-full flex w-full gap-2'>
@@ -29,7 +43,11 @@ export default function IssueClientPage({
         <Header />
         <main className='h-full w-full flex justify-center overflow-scroll'>
           {/* Issue Content - Title and Description */}
-          <Content />
+          {isLoading ? (
+            <Skeleton className='bg-weak h-full w-2/3 rounded-md' />
+          ) : (
+            <Content title={issue?.title} description={issue?.description} />
+          )}
         </main>
       </div>
       <Sidebar

--- a/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Sidebar } from '@buildit/ui/sidebar'
+
+import Header from '@/components/layout/header'
+import { api } from '@/lib/trpc/react'
+
+/**
+ * The IssuePage component is the page that displays the details of a specific issue.
+ * @param props The props for the IssuePage component.
+ * @param props.issueId The ID of the issue.
+ * @returns JSX.Element
+ */
+export default function IssueClientPage({
+  issueId,
+}: {
+  issueId: string
+}): JSX.Element {
+  // Fetch the issue details using the ID
+  const { data: issue } = api.issues.get_issue_by_id.useQuery(
+    { id: issueId },
+    { enabled: !!issueId },
+  )
+
+  console.log(issue)
+
+  return (
+    <div className='h-full flex w-full gap-2'>
+      <div className='h-full flex flex-col flex-grow'>
+        <Header />
+        <main className='bg-weak h-full w-full'>
+          {/* Issue Content - Title and Description */}
+        </main>
+      </div>
+      <Sidebar
+        collapsible='none'
+        className='sticky hidden lg:flex top-0 h-full border bg-weak rounded-md'
+      >
+        {/* Sidebar content - Properties of the issue */}
+      </Sidebar>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { Sidebar } from '@buildit/ui/sidebar'
 import { Skeleton } from '@buildit/ui/skeleton'
 import { toast } from '@buildit/ui/toast'
 
 import Content from '@/components/issue/content'
+import IssueProperties from '@/components/issue/issue-properties'
 import Header from '@/components/layout/header'
 import { api } from '@/lib/trpc/react'
 
@@ -38,8 +38,8 @@ export default function IssueClientPage({
   }
 
   return (
-    <div className='h-full flex w-full gap-2'>
-      <div className='h-full flex flex-col flex-grow gap-2'>
+    <div className='h-full w-full flex'>
+      <div className='h-full flex flex-col flex-grow gap-2 p-2'>
         <Header />
         <main className='h-full w-full flex justify-center overflow-scroll'>
           {/* Issue Content - Title and Description */}
@@ -50,12 +50,7 @@ export default function IssueClientPage({
           )}
         </main>
       </div>
-      <Sidebar
-        collapsible='none'
-        className='sticky hidden lg:flex top-0 h-full border bg-weak rounded-md'
-      >
-        {/* Sidebar content - Properties of the issue */}
-      </Sidebar>
+      <IssueProperties isLoading={isLoading} properties={issue} />
     </div>
   )
 }

--- a/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
@@ -46,7 +46,11 @@ export default function IssueClientPage({
           {isLoading ? (
             <Skeleton className='bg-weak h-full w-2/3 rounded-md' />
           ) : (
-            <Content title={issue?.title} description={issue?.description} />
+            <Content
+              id={issue?.id}
+              title={issue?.title}
+              description={issue?.description}
+            />
           )}
         </main>
       </div>

--- a/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page-client.tsx
@@ -2,6 +2,7 @@
 
 import { Sidebar } from '@buildit/ui/sidebar'
 
+import Content from '@/components/issue/content'
 import Header from '@/components/layout/header'
 import { api } from '@/lib/trpc/react'
 
@@ -22,14 +23,13 @@ export default function IssueClientPage({
     { enabled: !!issueId },
   )
 
-  console.log(issue)
-
   return (
     <div className='h-full flex w-full gap-2'>
-      <div className='h-full flex flex-col flex-grow'>
+      <div className='h-full flex flex-col flex-grow gap-2'>
         <Header />
-        <main className='bg-weak h-full w-full'>
+        <main className='h-full w-full flex justify-center overflow-scroll'>
           {/* Issue Content - Title and Description */}
+          <Content />
         </main>
       </div>
       <Sidebar

--- a/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
@@ -1,6 +1,4 @@
-import { Sidebar } from '@buildit/ui/sidebar'
-
-import Header from '@/components/layout/header'
+import IssueClientPage from './page-client'
 
 /**
  * The IssuePage component is the page that displays the details of a specific issue.
@@ -14,18 +12,5 @@ export default function IssuePage({
 }: {
   params: { id: string }
 }): JSX.Element {
-  return (
-    <div className='h-full flex w-full gap-2'>
-      <div className='h-full flex flex-col flex-grow'>
-        <Header />
-        <main className='bg-white'></main>
-      </div>
-      <Sidebar
-        collapsible='none'
-        className='sticky hidden lg:flex top-0 h-full border bg-weak rounded-md'
-      >
-        {/* Sidebar content */}
-      </Sidebar>
-    </div>
-  )
+  return <IssueClientPage issueId={params.id} />
 }

--- a/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Header from '@/components/layout/header'
+
+/**
+ * The IssuePage component is the page that displays the details of a specific issue.
+ * @param props The props for the IssuePage component.
+ * @param props.params The params for the IssuePage component.
+ * @param props.params.id The ID of the issue.
+ * @returns JSX.Element
+ */
+export default function IssuePage({
+  params,
+}: {
+  params: { id: string }
+}): JSX.Element {
+  console.log('Params:', params.id)
+
+  return (
+    <div className='h-full flex flex-col gap-2'>
+      <Header />
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/issue/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { Sidebar } from '@buildit/ui/sidebar'
+
 import Header from '@/components/layout/header'
 
 /**
@@ -12,11 +14,18 @@ export default function IssuePage({
 }: {
   params: { id: string }
 }): JSX.Element {
-  console.log('Params:', params.id)
-
   return (
-    <div className='h-full flex flex-col gap-2'>
-      <Header />
+    <div className='h-full flex w-full gap-2'>
+      <div className='h-full flex flex-col flex-grow'>
+        <Header />
+        <main className='bg-white'></main>
+      </div>
+      <Sidebar
+        collapsible='none'
+        className='sticky hidden lg:flex top-0 h-full border bg-weak rounded-md'
+      >
+        {/* Sidebar content */}
+      </Sidebar>
     </div>
   )
 }

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -26,7 +26,7 @@ export default async function DashboardRootLayout({
   return (
     <div className='flex bg-weak h-dvh'>
       <DashboardLayout>
-        <main className='bg-white p-2 h-full'>{children}</main>
+        <main className='bg-white h-full'>{children}</main>
       </DashboardLayout>
     </div>
   )

--- a/apps/web/src/app/(dashboard)/projects/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/projects/page-client.tsx
@@ -140,7 +140,7 @@ export default function ProjectsClientPage(): JSX.Element {
   }
 
   return (
-    <div className='h-full flex flex-col gap-2'>
+    <div className='h-full flex flex-col gap-2 p-2'>
       <Header>
         <div className='flex items-center gap-2'>
           <NewProjectModal>

--- a/apps/web/src/app/(dashboard)/team/[teamId]/active/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/team/[teamId]/active/page-client.tsx
@@ -115,7 +115,7 @@ export default function ActiveIssuesClientPage(): JSX.Element {
 
   return (
     <>
-      <div className='h-full flex flex-col gap-2'>
+      <div className='h-full flex flex-col gap-2 p-2'>
         <Header>
           <Button
             variant={'ghost'}

--- a/apps/web/src/app/(dashboard)/team/[teamId]/backlog/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/team/[teamId]/backlog/page-client.tsx
@@ -113,7 +113,7 @@ export default function BacklogIssuesClientPage(): JSX.Element {
 
   return (
     <>
-      <div className='h-full flex flex-col gap-2'>
+      <div className='h-full flex flex-col gap-2 p-2'>
         <Header>
           <Button
             variant={'ghost'}

--- a/apps/web/src/app/(dashboard)/team/[teamId]/projects/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/team/[teamId]/projects/page-client.tsx
@@ -145,7 +145,7 @@ export default function TeamProjectsClientPage(): JSX.Element {
   }
 
   return (
-    <div className='h-full flex flex-col gap-2'>
+    <div className='h-full flex flex-col gap-2 p-2'>
       <Header>
         <div className='flex items-center gap-2'>
           <NewProjectModal>

--- a/apps/web/src/app/(dashboard)/teams/page-client.tsx
+++ b/apps/web/src/app/(dashboard)/teams/page-client.tsx
@@ -33,7 +33,7 @@ export default function TeamsClientPage(): JSX.Element {
   }
   return (
     <>
-      <div className='h-full flex flex-col gap-2'>
+      <div className='h-full flex flex-col gap-2 p-2'>
         <Header>
           <div className='flex items-center gap-2'>
             <NewTeamModal>

--- a/apps/web/src/components/issue/content.tsx
+++ b/apps/web/src/components/issue/content.tsx
@@ -1,7 +1,77 @@
+import type { UpdateIssueContentPayload } from '@buildit/utils/validations'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+import Editor from '@buildit/editor'
+import { Form, FormControl, FormField, FormItem } from '@buildit/ui/form'
+import { Input } from '@buildit/ui/input'
+import { UpdateIssueContentSchema } from '@buildit/utils/validations'
+
+const defaultEditorValue = [
+  {
+    type: 'p',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+]
+
 /**
  * The Issue content component. This component displays the content of an issue which includes Title and the Description.
  * @returns JSX.Element
  */
 export default function Content(): JSX.Element {
-  return <div className=''></div>
+  const form = useForm<UpdateIssueContentPayload>({
+    resolver: zodResolver(UpdateIssueContentSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+    },
+  })
+
+  const localValue =
+    typeof window !== 'undefined' && localStorage.getItem('editorContent')
+  const content = localValue ? JSON.parse(localValue) : defaultEditorValue
+  return (
+    <Form {...form}>
+      <form action='' className='space-y-2 h-fit w-2/3'>
+        <FormField
+          control={form.control}
+          name='title'
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input
+                  className='bg-white border-none shadow-none focus-visible:ring-0 focus:ring-offset-0 p-0 text-base'
+                  placeholder='Issue Title'
+                  autoComplete='off'
+                  required
+                  {...field}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          name='description'
+          control={form.control}
+          render={() => (
+            <FormItem>
+              <FormControl>
+                <Editor
+                  content={content}
+                  onChange={(value) => {
+                    localStorage.setItem('editorContent', JSON.stringify(value))
+                  }}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  )
 }

--- a/apps/web/src/components/issue/content.tsx
+++ b/apps/web/src/components/issue/content.tsx
@@ -38,7 +38,7 @@ export default function Content({
   const form = useForm<UpdateIssueContentPayload>({
     resolver: zodResolver(UpdateIssueContentSchema),
     defaultValues: {
-      title: title,
+      title,
       description: description as string,
     },
   })
@@ -46,6 +46,30 @@ export default function Content({
   const content = description
     ? JSON.parse(description as string)
     : defaultEditorValue
+
+  const onSubmit = (data: Partial<UpdateIssueContentPayload>) => {
+    console.log('Submitted Values:', data)
+  }
+
+  const handleBlur = (field: keyof UpdateIssueContentPayload) => {
+    const currentValues = form.getValues()
+    const initialValues = form.formState.defaultValues ?? {}
+
+    if (field === 'description') {
+      const localContent = localStorage.getItem('editorContent')
+      const descriptionContent = localContent
+        ? (JSON.parse(localContent) as string)
+        : null
+
+      if (JSON.stringify(descriptionContent) !== initialValues.description) {
+        onSubmit({ description: descriptionContent })
+        localStorage.removeItem('editorContent')
+      }
+    } else if (currentValues[field] !== initialValues[field]) {
+      onSubmit({ [field]: currentValues[field] })
+    }
+  }
+
   return (
     <Form {...form}>
       <form className='space-y-2 h-fit w-2/3'>
@@ -61,6 +85,9 @@ export default function Content({
                   autoComplete='off'
                   required
                   {...field}
+                  onBlur={() => {
+                    handleBlur('title')
+                  }}
                 />
               </FormControl>
             </FormItem>
@@ -76,6 +103,9 @@ export default function Content({
                   content={content}
                   onChange={(value) => {
                     localStorage.setItem('editorContent', JSON.stringify(value))
+                  }}
+                  onBlur={() => {
+                    handleBlur('description')
                   }}
                 />
               </FormControl>

--- a/apps/web/src/components/issue/content.tsx
+++ b/apps/web/src/components/issue/content.tsx
@@ -19,25 +19,36 @@ const defaultEditorValue = [
   },
 ]
 
+interface ContentProps {
+  title: string | undefined
+  description: unknown | undefined
+}
+
 /**
  * The Issue content component. This component displays the content of an issue which includes Title and the Description.
+ * @param props The props for the Content component.
+ * @param props.title The title of the issue.
+ * @param props.description The description of the issue.
  * @returns JSX.Element
  */
-export default function Content(): JSX.Element {
+export default function Content({
+  title,
+  description,
+}: ContentProps): JSX.Element {
   const form = useForm<UpdateIssueContentPayload>({
     resolver: zodResolver(UpdateIssueContentSchema),
     defaultValues: {
-      title: '',
-      description: '',
+      title: title,
+      description: description as string,
     },
   })
 
-  const localValue =
-    typeof window !== 'undefined' && localStorage.getItem('editorContent')
-  const content = localValue ? JSON.parse(localValue) : defaultEditorValue
+  const content = description
+    ? JSON.parse(description as string)
+    : defaultEditorValue
   return (
     <Form {...form}>
-      <form action='' className='space-y-2 h-fit w-2/3'>
+      <form className='space-y-2 h-fit w-2/3'>
         <FormField
           control={form.control}
           name='title'

--- a/apps/web/src/components/issue/content.tsx
+++ b/apps/web/src/components/issue/content.tsx
@@ -1,0 +1,7 @@
+/**
+ * The Issue content component. This component displays the content of an issue which includes Title and the Description.
+ * @returns JSX.Element
+ */
+export default function Content(): JSX.Element {
+  return <div className=''></div>
+}

--- a/apps/web/src/components/issue/content.tsx
+++ b/apps/web/src/components/issue/content.tsx
@@ -31,9 +31,9 @@ interface ContentProps {
 /**
  * The Issue content component. This component displays the content of an issue which includes Title and the Description.
  * @param props The props for the Content component.
+ * @param props.id The id of the issue.
  * @param props.title The title of the issue.
  * @param props.description The description of the issue.
- * @param props.id
  * @returns JSX.Element
  */
 export default function Content({

--- a/apps/web/src/components/issue/default-properties.tsx
+++ b/apps/web/src/components/issue/default-properties.tsx
@@ -58,7 +58,11 @@ export default function DefaultProperties({
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <PropertiesMenu property='status' handleSelect={setStatusOption}>
+        <PropertiesMenu
+          property='status'
+          handleSelect={setStatusOption}
+          handleActiveItem={setActiveItem}
+        >
           <SidebarMenuButton
             className='capitalize text-sub font-medium'
             onClick={() => {
@@ -72,7 +76,11 @@ export default function DefaultProperties({
         </PropertiesMenu>
       </SidebarMenuItem>
       <SidebarMenuItem>
-        <PropertiesMenu property='priority' handleSelect={setPriorityOption}>
+        <PropertiesMenu
+          property='priority'
+          handleSelect={setPriorityOption}
+          handleActiveItem={setActiveItem}
+        >
           <SidebarMenuButton
             className='capitalize text-sub font-medium'
             onClick={() => {
@@ -86,7 +94,11 @@ export default function DefaultProperties({
         </PropertiesMenu>
       </SidebarMenuItem>
       <SidebarMenuItem>
-        <PropertiesMenu property='assignee' handleSelect={setAssigneeOption}>
+        <PropertiesMenu
+          property='assignee'
+          handleSelect={setAssigneeOption}
+          handleActiveItem={setActiveItem}
+        >
           <SidebarMenuButton
             className='capitalize text-sub font-medium'
             onClick={() => {

--- a/apps/web/src/components/issue/default-properties.tsx
+++ b/apps/web/src/components/issue/default-properties.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+
+import type { TUser } from '@buildit/utils/types'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@buildit/ui/avatar'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@buildit/ui/sidebar'
+
+import PropertiesMenu from '@/components/issue/properties-menu'
+import { Icons } from '@/components/ui/icons'
+import { useAssigneeOptions } from '@/configs/filter-settings'
+import { priorityConfig, statusConfig } from '@/configs/issue-config'
+import { getIcon } from '@/lib/get-icons'
+
+interface DefaultPropertiesProps {
+  status: string | null
+  priority: string | null
+  assignee: TUser | null | undefined
+}
+
+/**
+ * Default properties for the issue component. This component is used to display the properties of the issue - status, priority, assignee.
+ * @param props The props for the DefaultProperties component.
+ * @param props.status The status of the issue.
+ * @param props.priority The priority of the issue.
+ * @param props.assignee The assignee of the issue.
+ * @returns JSX.Element
+ */
+export default function DefaultProperties({
+  status,
+  priority,
+  assignee,
+}: DefaultPropertiesProps): JSX.Element {
+  const [activeItem, setActiveItem] = useState('')
+  const [statusOption, setStatusOption] = useState(status)
+  const [priorityOption, setPriorityOption] = useState(priority)
+  const [assigneeOption, setAssigneeOption] = useState(assignee?.id)
+
+  const assigneeOptions = useAssigneeOptions()
+
+  const statusIconName = statusConfig.find(
+    (item) => item.value === statusOption,
+  )?.icon
+  const priorityIconName = priorityConfig.find(
+    (item) => item.value === priorityOption,
+  )?.icon
+
+  const StatusIcon = getIcon(statusIconName)
+  const PriorityIcon = getIcon(priorityIconName)
+
+  const selectedAssignee = assigneeOptions.find(
+    (item) => item.value === assigneeOption,
+  )
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <PropertiesMenu property='status' handleSelect={setStatusOption}>
+          <SidebarMenuButton
+            className='capitalize text-sub font-medium'
+            onClick={() => {
+              setActiveItem('status')
+            }}
+            isActive={activeItem === 'status'}
+          >
+            {StatusIcon && <StatusIcon className='size-4 text-sub' />}
+            {statusOption}
+          </SidebarMenuButton>
+        </PropertiesMenu>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <PropertiesMenu property='priority' handleSelect={setPriorityOption}>
+          <SidebarMenuButton
+            className='capitalize text-sub font-medium'
+            onClick={() => {
+              setActiveItem('priority')
+            }}
+            isActive={activeItem === 'priority'}
+          >
+            {PriorityIcon && <PriorityIcon className='size-4 text-sub' />}
+            {priorityOption}
+          </SidebarMenuButton>
+        </PropertiesMenu>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <PropertiesMenu property='assignee' handleSelect={setAssigneeOption}>
+          <SidebarMenuButton
+            className='capitalize text-sub font-medium'
+            onClick={() => {
+              setActiveItem('assignee')
+            }}
+            isActive={activeItem === 'assignee'}
+          >
+            {selectedAssignee ? (
+              <>
+                <Avatar className='size-4'>
+                  <AvatarImage src={selectedAssignee.image ?? ''} />
+                  <AvatarFallback>
+                    {selectedAssignee.label?.at(0)}
+                  </AvatarFallback>
+                </Avatar>
+                {selectedAssignee.label}
+              </>
+            ) : (
+              <>
+                <Icons.userRoundPlus className='size-4 text-sub' />
+                Assign
+              </>
+            )}
+          </SidebarMenuButton>
+        </PropertiesMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/apps/web/src/components/issue/default-properties.tsx
+++ b/apps/web/src/components/issue/default-properties.tsx
@@ -8,14 +8,17 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@buildit/ui/sidebar'
+import { toast } from '@buildit/ui/toast'
 
 import PropertiesMenu from '@/components/issue/properties-menu'
 import { Icons } from '@/components/ui/icons'
 import { useAssigneeOptions } from '@/configs/filter-settings'
 import { priorityConfig, statusConfig } from '@/configs/issue-config'
 import { getIcon } from '@/lib/get-icons'
+import { api } from '@/lib/trpc/react'
 
 interface DefaultPropertiesProps {
+  id: string
   status: string | null
   priority: string | null
   assignee: TUser | null | undefined
@@ -24,12 +27,14 @@ interface DefaultPropertiesProps {
 /**
  * Default properties for the issue component. This component is used to display the properties of the issue - status, priority, assignee.
  * @param props The props for the DefaultProperties component.
+ * @param props.id The ID of the issue.
  * @param props.status The status of the issue.
  * @param props.priority The priority of the issue.
  * @param props.assignee The assignee of the issue.
  * @returns JSX.Element
  */
 export default function DefaultProperties({
+  id,
   status,
   priority,
   assignee,
@@ -55,12 +60,34 @@ export default function DefaultProperties({
     (item) => item.value === assigneeOption,
   )
 
+  const mutation = api.issues.update_issue_properties.useMutation({
+    onSuccess: ({ message }) => {
+      toast({
+        description: message,
+      })
+    },
+    onError: ({ message }) => {
+      toast({
+        variant: 'destructive',
+        title: 'Something went wrong!',
+        description: message,
+      })
+    },
+  })
+
+  const handleUpdate = (key: string, value: string | null) => {
+    mutation.mutate({ id: id, [key]: value })
+  }
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
         <PropertiesMenu
           property='status'
-          handleSelect={setStatusOption}
+          handleSelect={(value) => {
+            setStatusOption(value)
+            handleUpdate('status', value)
+          }}
           handleActiveItem={setActiveItem}
         >
           <SidebarMenuButton
@@ -78,7 +105,10 @@ export default function DefaultProperties({
       <SidebarMenuItem>
         <PropertiesMenu
           property='priority'
-          handleSelect={setPriorityOption}
+          handleSelect={(value) => {
+            setPriorityOption(value)
+            handleUpdate('priority', value)
+          }}
           handleActiveItem={setActiveItem}
         >
           <SidebarMenuButton
@@ -96,7 +126,10 @@ export default function DefaultProperties({
       <SidebarMenuItem>
         <PropertiesMenu
           property='assignee'
-          handleSelect={setAssigneeOption}
+          handleSelect={(value) => {
+            setAssigneeOption(value)
+            handleUpdate('assigneeId', value === 'unassigned' ? null : value)
+          }}
           handleActiveItem={setActiveItem}
         >
           <SidebarMenuButton

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -12,6 +12,7 @@ import {
 
 import DefaultProperties from '@/components/issue/default-properties'
 import Labels from '@/components/issue/labels'
+import ProjectProperties from '@/components/issue/projects-properties'
 
 interface IssuePropertiesProps {
   isLoading: boolean
@@ -67,6 +68,9 @@ export default function IssueProperties({
           <SidebarGroupLabel className='text-sub h-[30px]'>
             Project
           </SidebarGroupLabel>
+          <SidebarGroupContent>
+            {properties && <ProjectProperties project={properties.project} />}
+          </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
     </Sidebar>

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -44,6 +44,7 @@ export default function IssueProperties({
           <SidebarGroupContent>
             {properties && (
               <DefaultProperties
+                id={properties.id}
                 status={properties.status}
                 priority={properties.priority}
                 assignee={properties.assignee}

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -59,8 +59,9 @@ export default function IssueProperties({
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
-                {/* TODO: Implement labels in issues and pass the issue's labels to Labels component */}
-                <Labels />
+                {properties && (
+                  <Labels id={properties.id} labels={properties.labels} />
+                )}
               </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -70,7 +70,12 @@ export default function IssueProperties({
             Project
           </SidebarGroupLabel>
           <SidebarGroupContent>
-            {properties && <ProjectProperties project={properties.project} />}
+            {properties && (
+              <ProjectProperties
+                id={properties.id}
+                project={properties.project}
+              />
+            )}
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -6,9 +6,12 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
 } from '@buildit/ui/sidebar'
 
 import DefaultProperties from '@/components/issue/default-properties'
+import Labels from '@/components/issue/labels'
 
 interface IssuePropertiesProps {
   isLoading: boolean
@@ -46,6 +49,24 @@ export default function IssueProperties({
               />
             )}
           </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel className='text-sub h-[30px]'>
+            Labels
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                {/* TODO: Implement labels in issues and pass the issue's labels to Labels component */}
+                <Labels />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel className='text-sub h-[30px]'>
+            Project
+          </SidebarGroupLabel>
         </SidebarGroup>
       </SidebarContent>
     </Sidebar>

--- a/apps/web/src/components/issue/issue-properties.tsx
+++ b/apps/web/src/components/issue/issue-properties.tsx
@@ -1,0 +1,53 @@
+import type { TIssue } from '@buildit/utils/types'
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+} from '@buildit/ui/sidebar'
+
+import DefaultProperties from '@/components/issue/default-properties'
+
+interface IssuePropertiesProps {
+  isLoading: boolean
+  properties: Omit<TIssue, 'title' | 'description'> | undefined
+}
+
+/**
+ * The IssueProperties component is the sidebar that displays the properties of the issue.
+ * @param props The props for the IssueProperties component.
+ * @param props.isLoading Whether the issue is loading.
+ * @param props.properties The properties of the issue.
+ * @returns JSX.Element
+ */
+export default function IssueProperties({
+  isLoading,
+  properties,
+}: IssuePropertiesProps): JSX.Element {
+  return (
+    <Sidebar
+      collapsible='none'
+      className={`sticky hidden lg:flex top-0 h-full border-l  ${isLoading ? 'animate-pulse bg-weak/50' : 'bg-weak/70'}`}
+    >
+      {/* Sidebar content - Properties of the issue */}
+      <SidebarContent>
+        <SidebarGroup className='pb-0'>
+          <SidebarGroupLabel className='text-sub h-[30px]'>
+            Properties
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            {properties && (
+              <DefaultProperties
+                status={properties.status}
+                priority={properties.priority}
+                assignee={properties.assignee}
+              />
+            )}
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  )
+}

--- a/apps/web/src/components/issue/labels.tsx
+++ b/apps/web/src/components/issue/labels.tsx
@@ -1,0 +1,109 @@
+import { useRef, useState } from 'react'
+
+import { Badge } from '@buildit/ui/badge'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@buildit/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@buildit/ui/popover'
+import { SidebarMenuButton } from '@buildit/ui/sidebar'
+
+import { Icons } from '@/components/ui/icons'
+import { labelConfig } from '@/configs/issue-config'
+
+/**
+ * The Labels component is the sidebar group that displays the labels of the issue.
+ * @returns JSX.Element
+ */
+export default function Labels(): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const commandRef = useRef<HTMLDivElement>(null)
+
+  const [activeItem, setActiveItem] = useState('')
+  const [labelOption, setLabelOption] = useState<string[]>([])
+
+  const handleSelect = (value: string) => {
+    setLabelOption(
+      labelOption.includes(value)
+        ? labelOption.filter((item) => item !== value)
+        : [...labelOption, value],
+    )
+    setActiveItem('')
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className='flex flex-wrap items-center gap-2' asChild>
+        <div>
+          {labelOption.length > 0 && (
+            <div className='flex flex-wrap gap-2'>
+              {labelOption.map((item) => (
+                <Badge
+                  key={item}
+                  variant='outline'
+                  className='bg-white px-2 py-0.5 flex items-center h-8'
+                >
+                  {item}
+                </Badge>
+              ))}
+            </div>
+          )}
+          <SidebarMenuButton
+            className={`text-sub font-medium justify-start ${labelOption.length > 0 ? 'w-fit' : 'w-full'}`}
+            onClick={() => {
+              setActiveItem('label')
+            }}
+            isActive={activeItem === 'label'}
+          >
+            {labelOption.length > 0 ? (
+              <span className='flex items-center'>
+                <Icons.plus className='size-4 text-sub' />
+              </span>
+            ) : (
+              <span className='flex items-center'>
+                <Icons.tag className='size-4 text-sub mr-2' />
+                Add Label
+              </span>
+            )}
+          </SidebarMenuButton>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent className='w-[200px] p-0' align='start' side='left'>
+        <Command ref={commandRef}>
+          <CommandInput
+            placeholder='Search labels...'
+            className='px-2'
+            value={inputValue}
+            onValueChange={setInputValue}
+          />
+          <CommandList>
+            <CommandEmpty>No labels found.</CommandEmpty>
+            <CommandGroup>
+              {labelConfig.map((item) => (
+                <CommandItem
+                  key={item.value}
+                  onSelect={() => {
+                    handleSelect(item.value)
+                  }}
+                  className='flex items-center px-2 py-1.5 cursor-pointer'
+                >
+                  <div className='w-4 h-4 mr-2 flex items-center justify-center'>
+                    {labelOption.includes(item.value) && (
+                      <Icons.checkIcon className='size-4 text-sub' />
+                    )}
+                  </div>
+                  {item.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/issue/projects-properties.tsx
+++ b/apps/web/src/components/issue/projects-properties.tsx
@@ -7,22 +7,27 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@buildit/ui/sidebar'
+import { toast } from '@buildit/ui/toast'
 
 import PropertiesMenu from '@/components/issue/properties-menu'
 import { Icons } from '@/components/ui/icons'
 import { useProjectOptions } from '@/configs/filter-settings'
+import { api } from '@/lib/trpc/react'
 
 interface ProjectPropertiesProps {
+  id: string
   project: TProject | null | undefined
 }
 
 /**
  * Default properties for the issue component. This component is used to display the properties of the issue - status, priority, assignee.
  * @param props The props for the DefaultProperties component.
+ * @param props.id The ID of the issue.
  * @param props.project The project for which the properties are to be displayed.
  * @returns JSX.Element
  */
 export default function ProjectProperties({
+  id,
   project,
 }: ProjectPropertiesProps): JSX.Element {
   const [activeItem, setActiveItem] = useState('')
@@ -34,12 +39,33 @@ export default function ProjectProperties({
     (item) => item.value === projectOption,
   )
 
+  const mutation = api.issues.update_issue_properties.useMutation({
+    onSuccess: ({ message }) => {
+      toast({
+        description: message,
+      })
+    },
+    onError: ({ message }) => {
+      toast({
+        variant: 'destructive',
+        title: 'Something went wrong!',
+        description: message,
+      })
+    },
+  })
+
+  const handleUpdate = (key: string, value: string | null) => {
+    mutation.mutate({ id: id, [key]: value })
+  }
   return (
     <SidebarMenu>
       <SidebarMenuItem>
         <PropertiesMenu
           property='project'
-          handleSelect={setProjectOption}
+          handleSelect={(value) => {
+            setProjectOption(value)
+            handleUpdate('projectId', value === 'no project' ? null : value)
+          }}
           handleActiveItem={setActiveItem}
         >
           <SidebarMenuButton

--- a/apps/web/src/components/issue/projects-properties.tsx
+++ b/apps/web/src/components/issue/projects-properties.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+
+import type { TProject } from '@buildit/utils/types'
+
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@buildit/ui/sidebar'
+
+import PropertiesMenu from '@/components/issue/properties-menu'
+import { Icons } from '@/components/ui/icons'
+import { useProjectOptions } from '@/configs/filter-settings'
+
+interface ProjectPropertiesProps {
+  project: TProject | null | undefined
+}
+
+/**
+ * Default properties for the issue component. This component is used to display the properties of the issue - status, priority, assignee.
+ * @param props The props for the DefaultProperties component.
+ * @param props.project The project for which the properties are to be displayed.
+ * @returns JSX.Element
+ */
+export default function ProjectProperties({
+  project,
+}: ProjectPropertiesProps): JSX.Element {
+  const [activeItem, setActiveItem] = useState('')
+  const [projectOption, setProjectOption] = useState(project?.id)
+
+  const projectsOptions = useProjectOptions()
+
+  const selectedProject = projectsOptions.find(
+    (item) => item.value === projectOption,
+  )
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <PropertiesMenu
+          property='project'
+          handleSelect={setProjectOption}
+          handleActiveItem={setActiveItem}
+        >
+          <SidebarMenuButton
+            className='capitalize text-sub font-medium'
+            onClick={() => {
+              setActiveItem('project')
+            }}
+            isActive={activeItem === 'project'}
+          >
+            {selectedProject ? (
+              <>
+                <Icons.hexagon className='size-4 text-sub' />
+                <span className='normal-case'>{selectedProject.label}</span>
+              </>
+            ) : (
+              <>
+                <Icons.hexagon className='size-4 text-sub' />
+                <span className='normal-case'>Add to project</span>
+              </>
+            )}
+          </SidebarMenuButton>
+        </PropertiesMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/apps/web/src/components/issue/properties-menu.tsx
+++ b/apps/web/src/components/issue/properties-menu.tsx
@@ -21,6 +21,7 @@ import {
   priorityOptions,
   statusOptions,
   useAssigneeOptions,
+  useProjectOptions,
 } from '@/configs/filter-settings'
 import { getIcon } from '@/lib/get-icons'
 
@@ -40,7 +41,7 @@ export default function PropertiesMenu({
   handleActiveItem,
 }: {
   children: ReactNode
-  property: 'status' | 'priority' | 'team' | 'assignee'
+  property: 'status' | 'priority' | 'team' | 'assignee' | 'project'
   handleSelect: (value: string) => void
   handleActiveItem: (value: string) => void
 }): JSX.Element {
@@ -50,6 +51,8 @@ export default function PropertiesMenu({
 
   const assigneeOptions = useAssigneeOptions()
 
+  const projectsOptions = useProjectOptions()
+
   const getCurrentOptions = () => {
     switch (property) {
       case 'status':
@@ -58,6 +61,8 @@ export default function PropertiesMenu({
         return priorityOptions
       case 'assignee':
         return assigneeOptions
+      case 'project':
+        return projectsOptions
       default:
         return []
     }
@@ -93,6 +98,22 @@ export default function PropertiesMenu({
                   >
                     <Icons.userCircle2 className='size-4 text-sub mr-2' />
                     No Assignee
+                  </CommandItem>
+                  <CommandSeparator className='my-1 bg-soft/50' />
+                </>
+              )}
+              {property === 'project' && (
+                <>
+                  <CommandItem
+                    key='no project'
+                    onSelect={() => {
+                      handleSelect('no project')
+                      setOpen(false)
+                      handleActiveItem('')
+                    }}
+                  >
+                    <Icons.hexagon className='size-4 text-sub mr-2' />
+                    No Project
                   </CommandItem>
                   <CommandSeparator className='my-1 bg-soft/50' />
                 </>

--- a/apps/web/src/components/issue/properties-menu.tsx
+++ b/apps/web/src/components/issue/properties-menu.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import type { ReactNode } from 'react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@buildit/ui/avatar'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@buildit/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@buildit/ui/popover'
+
+import { Icons } from '@/components/ui/icons'
+import {
+  priorityOptions,
+  statusOptions,
+  useAssigneeOptions,
+} from '@/configs/filter-settings'
+import { getIcon } from '@/lib/get-icons'
+
+/**
+ * PropertiesMenu component. This component is used to display the menu-options for particular property.
+ * @param props The props for the PropertiesMenu component.
+ * @param props.children The trigger of the PropertiesMenu component.
+ * @param props.property The property name for which the menu-options are to be displayed.
+ * @param props.handleSelect The function to be called when an option is selected.
+ * @returns JSX.Element
+ */
+export default function PropertiesMenu({
+  children,
+  property,
+  handleSelect,
+}: {
+  children: ReactNode
+  property: 'status' | 'priority' | 'team' | 'assignee'
+  handleSelect: (value: string) => void
+}): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const commandRef = useRef<HTMLDivElement>(null)
+
+  const assigneeOptions = useAssigneeOptions()
+
+  const getCurrentOptions = () => {
+    switch (property) {
+      case 'status':
+        return statusOptions
+      case 'priority':
+        return priorityOptions
+      case 'assignee':
+        return assigneeOptions
+      default:
+        return []
+    }
+  }
+
+  const currentOptions = getCurrentOptions()
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className='flex items-center gap-2 w-full'>
+        {children}
+      </PopoverTrigger>
+      <PopoverContent className='w-[200px] p-0' align='start' side='left'>
+        <Command ref={commandRef}>
+          <CommandInput
+            placeholder={`Search ${property}...`}
+            className='px-0'
+            value={inputValue}
+            onValueChange={setInputValue}
+          />
+          <CommandList>
+            <CommandEmpty>No {property} found.</CommandEmpty>
+            <CommandGroup>
+              {property === 'assignee' && (
+                <>
+                  <CommandItem
+                    key='unassigned'
+                    onSelect={() => {
+                      handleSelect('unassigned')
+                    }}
+                  >
+                    <Icons.userCircle2 className='size-4 text-sub mr-2' />
+                    No Assignee
+                  </CommandItem>
+                  <CommandSeparator className='my-1 bg-soft/50' />
+                </>
+              )}
+              {currentOptions.length > 0 ? (
+                currentOptions.map((option) => {
+                  const Icon = getIcon(option.icon)
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      onSelect={() => {
+                        handleSelect(option.value)
+                      }}
+                    >
+                      {option.icon === 'image' ? (
+                        <Avatar className='size-4 mr-2'>
+                          {'image' in option && (
+                            <AvatarImage src={option.image ?? ''} />
+                          )}
+                          <AvatarFallback>
+                            <Icons.userCircle2 className='size-4 text-sub' />
+                          </AvatarFallback>
+                        </Avatar>
+                      ) : (
+                        <>{Icon && <Icon className='size-4 text-sub mr-2' />}</>
+                      )}
+                      {option.label}
+                    </CommandItem>
+                  )
+                })
+              ) : (
+                <CommandItem disabled>No options available</CommandItem>
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/issue/properties-menu.tsx
+++ b/apps/web/src/components/issue/properties-menu.tsx
@@ -30,16 +30,19 @@ import { getIcon } from '@/lib/get-icons'
  * @param props.children The trigger of the PropertiesMenu component.
  * @param props.property The property name for which the menu-options are to be displayed.
  * @param props.handleSelect The function to be called when an option is selected.
+ * @param props.handleActiveItem The function to be called when an item is active.
  * @returns JSX.Element
  */
 export default function PropertiesMenu({
   children,
   property,
   handleSelect,
+  handleActiveItem,
 }: {
   children: ReactNode
   property: 'status' | 'priority' | 'team' | 'assignee'
   handleSelect: (value: string) => void
+  handleActiveItem: (value: string) => void
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -84,6 +87,8 @@ export default function PropertiesMenu({
                     key='unassigned'
                     onSelect={() => {
                       handleSelect('unassigned')
+                      setOpen(false)
+                      handleActiveItem('')
                     }}
                   >
                     <Icons.userCircle2 className='size-4 text-sub mr-2' />
@@ -100,6 +105,8 @@ export default function PropertiesMenu({
                       key={option.value}
                       onSelect={() => {
                         handleSelect(option.value)
+                        setOpen(false)
+                        handleActiveItem('')
                       }}
                     >
                       {option.icon === 'image' ? (

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -26,7 +26,7 @@ import { api } from '@/lib/trpc/react'
 export default function Header({
   children,
 }: {
-  children: React.ReactNode
+  children?: React.ReactNode
 }): JSX.Element {
   const pathname = usePathname()
 
@@ -57,9 +57,19 @@ export default function Header({
                     <Skeleton className='w-52 h-4' />
                   ) : (
                     <>
-                      <BreadcrumbItem>{teamName}</BreadcrumbItem>
-                      <BreadcrumbSeparator />
-                      <BreadcrumbPage>{title}</BreadcrumbPage>
+                      {teamQuery ? (
+                        <>
+                          <BreadcrumbItem>{teamName}</BreadcrumbItem>
+                          <BreadcrumbSeparator />
+                          <BreadcrumbPage>{title}</BreadcrumbPage>
+                        </>
+                      ) : (
+                        <>
+                          <BreadcrumbPage>Issue</BreadcrumbPage>
+                          <BreadcrumbSeparator />
+                          <BreadcrumbPage>{teamName}</BreadcrumbPage>
+                        </>
+                      )}
                     </>
                   )}
                 </>

--- a/apps/web/src/configs/filter-settings.ts
+++ b/apps/web/src/configs/filter-settings.ts
@@ -129,3 +129,27 @@ export const useAssigneeOptions = () => {
       .filter(Boolean) ?? []
   )
 }
+
+export const useProjectOptions = () => {
+  const {
+    data: projects,
+    isLoading,
+    error,
+  } = api.project.get_projects.useQuery()
+
+  if (isLoading) {
+    return []
+  }
+
+  if (error) {
+    return []
+  }
+
+  return (
+    projects?.map((project) => ({
+      value: project.id,
+      label: project.name,
+      icon: 'hexagon',
+    })) ?? []
+  )
+}

--- a/apps/web/src/configs/issue-config.ts
+++ b/apps/web/src/configs/issue-config.ts
@@ -66,3 +66,21 @@ export const priorityConfig: FilterSettings[] = [
     icon: 'signalLow',
   },
 ]
+
+export const labelConfig: FilterSettings[] = [
+  {
+    value: 'bug',
+    label: 'Bug',
+    icon: 'red',
+  },
+  {
+    value: 'feature',
+    label: 'Feature',
+    icon: 'blue',
+  },
+  {
+    value: 'enhancement',
+    label: 'Enhancement',
+    icon: 'purple',
+  },
+]

--- a/apps/web/src/configs/issue-config.ts
+++ b/apps/web/src/configs/issue-config.ts
@@ -1,0 +1,68 @@
+import type { FilterSettings } from '@buildit/utils/types/configs'
+
+export const statusConfig: FilterSettings[] = [
+  {
+    value: 'backlog',
+    label: 'Backlog',
+    icon: 'backlog',
+  },
+  {
+    value: 'planned',
+    label: 'Planned',
+    icon: 'hexagon',
+  },
+  {
+    value: 'todo',
+    label: 'Todo',
+    icon: 'todo',
+  },
+  {
+    value: 'in progress',
+    label: 'In Progress',
+    icon: 'inProgress',
+  },
+  {
+    value: 'completed',
+    label: 'Completed',
+    icon: 'done',
+  },
+
+  {
+    value: 'done',
+    label: 'Done',
+    icon: 'done',
+  },
+  {
+    value: 'canceled',
+    label: 'Canceled',
+    icon: 'canceled',
+  },
+]
+
+export const priorityConfig: FilterSettings[] = [
+  {
+    value: 'no priority',
+    label: 'No Priority',
+    icon: 'minus',
+  },
+  {
+    value: 'urgent',
+    label: 'Urgent',
+    icon: 'triangleAlert',
+  },
+  {
+    value: 'high',
+    label: 'High',
+    icon: 'signalHigh',
+  },
+  {
+    value: 'medium',
+    label: 'Medium',
+    icon: 'signalMedium',
+  },
+  {
+    value: 'low',
+    label: 'Low',
+    icon: 'signalLow',
+  },
+]

--- a/apps/web/src/lib/get-icons.ts
+++ b/apps/web/src/lib/get-icons.ts
@@ -1,0 +1,12 @@
+import { Icons } from '@/components/ui/icons'
+
+/**
+ * This file is used to get the icon component based on the icon name.
+ * @param iconName The name of the icon.
+ * @returns The icon component.
+ */
+export function getIcon(
+  iconName: string | undefined,
+): React.ElementType | null {
+  return iconName ? Icons[iconName as keyof typeof Icons] : null
+}

--- a/packages/api/src/routers/issues.ts
+++ b/packages/api/src/routers/issues.ts
@@ -5,6 +5,7 @@ import { db, eq } from '@buildit/db'
 import { issueTable, teamTable, workspaceTable } from '@buildit/db/schema'
 import {
   CreateIssueInputSchema,
+  UpdateIssueContentSchema,
   UpdateIssuePropertiesSchema,
 } from '@buildit/utils/validations'
 
@@ -162,6 +163,29 @@ export const issuesRouter = createRouter({
 
       return {
         message: `${issueId} - ${input.title}`,
+      }
+    }),
+
+  update_issue_content: protectedProcedure
+    .input(UpdateIssueContentSchema)
+    .mutation(async ({ input }) => {
+      const { id, ...updates } = input
+
+      // Filter out undefined fields to handle partial updates
+      const filteredUpdates = Object.fromEntries(
+        Object.entries(updates).filter(([_, value]) => value !== undefined),
+      )
+
+      // Get the key of the filtered updates
+      const key = Object.keys(filteredUpdates).at(0)
+
+      await db
+        .update(issueTable)
+        .set(filteredUpdates)
+        .where(eq(issueTable.id, id))
+
+      return {
+        message: `Issue ${key} updated successfully.`,
       }
     }),
   update_issue_properties: protectedProcedure

--- a/packages/api/src/routers/issues.ts
+++ b/packages/api/src/routers/issues.ts
@@ -198,13 +198,16 @@ export const issuesRouter = createRouter({
         Object.entries(updates).filter(([_, value]) => value !== undefined),
       )
 
+      // Get the key of the filtered updates
+      const key = Object.keys(filteredUpdates).at(0)
+
       await db
         .update(issueTable)
         .set(filteredUpdates)
         .where(eq(issueTable.id, id))
 
       return {
-        message: 'Issue updated.',
+        message: `Issue ${key === 'assigneeId' ? 'assignee' : key} updated successfully.`,
       }
     }),
   delete_issue: protectedProcedure

--- a/packages/api/src/routers/issues.ts
+++ b/packages/api/src/routers/issues.ts
@@ -199,7 +199,16 @@ export const issuesRouter = createRouter({
       )
 
       // Get the key of the filtered updates
-      const key = Object.keys(filteredUpdates).at(0)
+      let key = Object.keys(filteredUpdates).at(0)
+
+      switch (key) {
+        case 'assigneeId':
+          key = 'assignee'
+          break
+        case 'projectId':
+          key = 'project'
+          break
+      }
 
       await db
         .update(issueTable)
@@ -207,7 +216,7 @@ export const issuesRouter = createRouter({
         .where(eq(issueTable.id, id))
 
       return {
-        message: `Issue ${key === 'assigneeId' ? 'assignee' : key} updated successfully.`,
+        message: `Issue ${key} updated successfully.`,
       }
     }),
   delete_issue: protectedProcedure

--- a/packages/api/src/routers/issues.ts
+++ b/packages/api/src/routers/issues.ts
@@ -40,6 +40,29 @@ const generateIssueId = (team: { teamId: string; issueCounter: number }) => {
 }
 
 export const issuesRouter = createRouter({
+  get_issue_by_id: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      const issue = await db.query.issueTable.findFirst({
+        where: eq(issueTable.issueId, input.id),
+        with: {
+          assignee: true,
+          project: true,
+          reporter: true,
+          team: true,
+        },
+      })
+
+      if (!issue) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Issue not found',
+          cause: 'The issue does not exist',
+        })
+      }
+
+      return issue
+    }),
   get_issues: protectedProcedure.query(async ({ ctx }) => {
     const workspace = await getWorkspace(ctx.user.id)
 

--- a/packages/db/drizzle/0005_next_clea.sql
+++ b/packages/db/drizzle/0005_next_clea.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `issue` ADD `labels` text;

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,726 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "153d6683-aba6-4f4a-b1c7-f1891bc199fb",
+  "prevId": "dd1bf3d7-746e-437c-bb54-13371188e166",
+  "tables": {
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_codes_user_id_user_id_fk": {
+          "name": "email_verification_codes_user_id_user_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "oauth_account": {
+      "name": "oauth_account",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_account_user_id_user_id_fk": {
+          "name": "oauth_account_user_id_user_id_fk",
+          "tableFrom": "oauth_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_account_provider_id_provider_user_id_pk": {
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ],
+          "name": "oauth_account_provider_id_provider_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "issue": {
+      "name": "issue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporterId": {
+          "name": "reporterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "issue_issueId_unique": {
+          "name": "issue_issueId_unique",
+          "columns": [
+            "issueId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issue_reporterId_user_id_fk": {
+          "name": "issue_reporterId_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_assigneeId_user_id_fk": {
+          "name": "issue_assigneeId_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_workspaceId_workspace_id_fk": {
+          "name": "issue_workspaceId_workspace_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_teamId_team_id_fk": {
+          "name": "issue_teamId_team_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_projectId_project_id_fk": {
+          "name": "issue_projectId_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "project": {
+      "name": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leadId": {
+          "name": "leadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_admin_user_id_fk": {
+          "name": "project_admin_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_leadId_user_id_fk": {
+          "name": "project_leadId_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "leadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_teamId_team_id_fk": {
+          "name": "project_teamId_team_id_fk",
+          "tableFrom": "project",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issueCounter": {
+          "name": "issueCounter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "admin": {
+          "name": "admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_teamId_unique": {
+          "name": "team_teamId_unique",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_admin_user_id_fk": {
+          "name": "team_admin_user_id_fk",
+          "tableFrom": "team",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_workspaceId_workspace_id_fk": {
+          "name": "team_workspaceId_workspace_id_fk",
+          "tableFrom": "team",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "workspace": {
+      "name": "workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_userId_user_id_fk": {
+          "name": "workspace_userId_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1731672694611,
       "tag": "0004_dusty_nighthawk",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1732258241592,
+      "tag": "0005_next_clea",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue/issue.ts
+++ b/packages/db/src/schema/issue/issue.ts
@@ -19,6 +19,7 @@ export const issueTable = sqliteTable('issue', {
   priority: text('priority', {
     enum: ['low', 'medium', 'high', 'urgent', 'no priority'],
   }),
+  labels: text('labels', { mode: 'json' }).$type<string[]>(),
   reporterId: text('reporterId').references(() => userTable.id, {
     onDelete: 'cascade',
   }),

--- a/packages/utils/src/types/index.ts
+++ b/packages/utils/src/types/index.ts
@@ -61,6 +61,7 @@ export interface TIssue {
   description: unknown | null
   status: 'backlog' | 'todo' | 'in progress' | 'done' | 'canceled' | null
   priority: 'low' | 'medium' | 'high' | 'urgent' | 'no priority' | null
+  labels: string[] | null
   reporterId: string | null
   assigneeId: string | null
   createdAt: Date | null

--- a/packages/utils/src/validations/issue/index.ts
+++ b/packages/utils/src/validations/issue/index.ts
@@ -24,3 +24,11 @@ export const UpdateIssuePropertiesSchema = z.object({
   priority: z.optional(z.enum(PRIORITY)),
   assigneeId: z.optional(z.nullable(z.string())),
 })
+
+export const UpdateIssueContentSchema = z.object({
+  id: z.string(),
+  title: z.optional(z.string().min(1, { message: 'Title is required.' })),
+  description: z.optional(z.nullable(z.string())),
+})
+
+export type UpdateIssueContentPayload = z.infer<typeof UpdateIssueContentSchema>

--- a/packages/utils/src/validations/issue/index.ts
+++ b/packages/utils/src/validations/issue/index.ts
@@ -24,6 +24,7 @@ export const UpdateIssuePropertiesSchema = z.object({
   priority: z.optional(z.enum(PRIORITY)),
   assigneeId: z.optional(z.nullable(z.string())),
   projectId: z.optional(z.nullable(z.string())),
+  labels: z.optional(z.array(z.string())),
 })
 
 export const UpdateIssueContentSchema = z.object({

--- a/packages/utils/src/validations/issue/index.ts
+++ b/packages/utils/src/validations/issue/index.ts
@@ -23,6 +23,7 @@ export const UpdateIssuePropertiesSchema = z.object({
   status: z.optional(z.enum(STATUS)),
   priority: z.optional(z.enum(PRIORITY)),
   assigneeId: z.optional(z.nullable(z.string())),
+  projectId: z.optional(z.nullable(z.string())),
 })
 
 export const UpdateIssueContentSchema = z.object({


### PR DESCRIPTION
### Description:
This pull request added `issue/[id]` page, which displays the particular issue in details like the issue `title`, `description`, and properties like `status`, `priority`, `assignees`, `labels` and `projects`. Users can also edit the issue and it's contents with their properties.

### Key changes:
- Added `issue/[id]` page.
- Added a sidebar for `issue-properties`.
- Added `api` for updating the `contents` and the issue `properties`.
- Added `labels` column in `issue` table.